### PR TITLE
Refactor PBESettings

### DIFF
--- a/PokemonBattleEngine/Battle/Battle.cs
+++ b/PokemonBattleEngine/Battle/Battle.cs
@@ -50,6 +50,10 @@ namespace Kermalis.PokemonBattleEngine.Battle
             {
                 throw new ArgumentOutOfRangeException(nameof(battleFormat));
             }
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
             if (team0Party == null)
             {
                 throw new ArgumentNullException(nameof(team0Party));
@@ -77,6 +81,10 @@ namespace Kermalis.PokemonBattleEngine.Battle
             if (battleFormat >= PBEBattleFormat.MAX)
             {
                 throw new ArgumentOutOfRangeException(nameof(battleFormat));
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
             }
             BattleFormat = battleFormat;
             Settings = settings;

--- a/PokemonBattleEngine/Battle/BattleActions.cs
+++ b/PokemonBattleEngine/Battle/BattleActions.cs
@@ -21,14 +21,14 @@ namespace Kermalis.PokemonBattleEngine.Battle
         [FieldOffset(4)]
         public byte SwitchPokemonId;
 
-        internal byte[] ToBytes()
+        internal List<byte> ToBytes()
         {
             var bytes = new List<byte>();
             bytes.Add(PokemonId);
             bytes.Add((byte)Decision);
             bytes.AddRange(BitConverter.GetBytes((ushort)FightMove));
             bytes.Add(SwitchPokemonId);
-            return bytes.ToArray();
+            return bytes;
         }
         internal static PBEAction FromBytes(BinaryReader r)
         {

--- a/PokemonBattleEngine/Battle/BattleEffects.cs
+++ b/PokemonBattleEngine/Battle/BattleEffects.cs
@@ -3184,7 +3184,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
                 failReason = PBEFailReason.None;
                 ushort DamageFunc(PBEPokemon target)
                 {
-                    return (ushort)(user.Level * (PBEUtils.RandomInt(0, Settings.MaxLevel) + (Settings.MaxLevel / 2)) / Settings.MaxLevel);
+                    return (ushort)(user.Level * (PBEUtils.RandomInt(0, 100) + 50) / 100);
                 }
                 FixedDamageHit(user, targets, move, ref targetSuccess, DamageFunc);
             }

--- a/PokemonBattleEngine/Battle/BattleReplay.cs
+++ b/PokemonBattleEngine/Battle/BattleReplay.cs
@@ -1,4 +1,5 @@
-﻿using Kermalis.PokemonBattleEngine.Data;
+﻿using Ether.Network.Packets;
+using Kermalis.PokemonBattleEngine.Data;
 using Kermalis.PokemonBattleEngine.Packets;
 using System;
 using System.Collections.Generic;
@@ -85,7 +86,12 @@ namespace Kermalis.PokemonBattleEngine.Battle
             int numEvents = r.ReadInt32();
             for (int i = 0; i < numEvents; i++)
             {
-                Events.Add(packetProcessor.CreatePacket(r.ReadBytes(r.ReadInt16())));
+                INetPacket packet = packetProcessor.CreatePacket(r.ReadBytes(r.ReadInt16()));
+                if (packet is PBEWinnerPacket wp)
+                {
+                    Winner = wp.WinningTeam;
+                }
+                Events.Add(packet);
             }
 
             BattleState = PBEBattleState.Ended;

--- a/PokemonBattleEngine/Battle/BattleReplay.cs
+++ b/PokemonBattleEngine/Battle/BattleReplay.cs
@@ -27,6 +27,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
 
             var bytes = new List<byte>();
             bytes.AddRange(BitConverter.GetBytes(CurrentReplayVersion));
+            bytes.AddRange(Settings.ToBytes());
             bytes.Add((byte)BattleFormat);
 
             bytes.AddRange(PBEUtils.StringToBytes(Teams[0].TrainerName));
@@ -52,7 +53,6 @@ namespace Kermalis.PokemonBattleEngine.Battle
 
         public static PBEBattle LoadReplay(string path)
         {
-            PBESettings settings = PBESettings.DefaultSettings;
             byte[] fileBytes = File.ReadAllBytes(path);
             using (var s = new MemoryStream(fileBytes))
             using (var r = new BinaryReader(s))
@@ -71,6 +71,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
 
                 ushort version = r.ReadUInt16();
 
+                var settings = PBESettings.FromBytes(r);
                 var battle = new PBEBattle((PBEBattleFormat)r.ReadByte(), settings);
 
                 battle.Teams[0].TrainerName = PBEUtils.StringFromBytes(r);

--- a/PokemonBattleEngine/Battle/Pokemon.cs
+++ b/PokemonBattleEngine/Battle/Pokemon.cs
@@ -799,12 +799,12 @@ namespace Kermalis.PokemonBattleEngine.Battle
         }
 
         // ToBytes() and FromBytes() will only be used when the server sends you your team Ids, so they do not need to contain all info
-        internal byte[] ToBytes()
+        internal List<byte> ToBytes()
         {
             var bytes = new List<byte>();
             bytes.Add(Id);
             bytes.AddRange(Shell.ToBytes());
-            return bytes.ToArray();
+            return bytes;
         }
         internal static PBEPokemon FromBytes(BinaryReader r, PBETeam team)
         {

--- a/PokemonBattleEngine/Battle/Pokemon.cs
+++ b/PokemonBattleEngine/Battle/Pokemon.cs
@@ -12,18 +12,10 @@ namespace Kermalis.PokemonBattleEngine.Battle
     /// <summary>Represents a specific Pokémon during a battle.</summary>
     public sealed class PBEPokemon
     {
-        /// <summary>
-        /// The team this Pokémon belongs to in its battle.
-        /// </summary>
+        /// <summary>The team this Pokémon belongs to in its battle.</summary>
         public PBETeam Team { get; }
-        /// <summary>
-        /// The Pokémon's ID in its battle.
-        /// </summary>
+        /// <summary>The Pokémon's ID in its battle.</summary>
         public byte Id { get; }
-        /// <summary>
-        /// The shell that was used to create this Pokémon.
-        /// </summary>
-        public PBEPokemonShell Shell { get; }
 
         /// <summary>
         /// The Pokémon's nickname with its gender attached.
@@ -84,103 +76,62 @@ namespace Kermalis.PokemonBattleEngine.Battle
         public PBEEffortValueCollection EffortValues { get; set; }
         public PBEIndividualValueCollection IndividualValues { get; set; }
         public byte Friendship { get; set; }
-        /// <summary>
-        /// The Pokémon's level.
-        /// </summary>
+        /// <summary>The Pokémon's level.</summary>
         public byte Level { get; set; }
-        /// <summary>
-        /// The Pokémon's nature.
-        /// </summary>
+        /// <summary>The Pokémon's nature.</summary>
         public PBENature Nature { get; set; }
-        public byte[] PPUps { get; set; }
+        /// <summary>The moves the Pokémon had upon entering battle.</summary>
+        public PBEMove[] OriginalMoves { get; set; }
+        /// <summary>The PP-Ups the Pokémon had upon entering battle.</summary>
+        public byte[] OriginalPPUps { get; set; }
 
-        /// <summary>
-        /// The Pokémon's field position.
-        /// </summary>
+        /// <summary>The Pokémon's field position.</summary>
         public PBEFieldPosition FieldPosition { get; set; }
-        /// <summary>
-        /// The Pokémon's current ability.
-        /// </summary>
+        /// <summary>The Pokémon's current ability.</summary>
         public PBEAbility Ability { get; set; }
-        /// <summary>
-        /// The Pokémon's normal ability.
-        /// </summary>
+        /// <summary>The ability the Pokémon had upon entering battle. </summary>
         public PBEAbility OriginalAbility { get; set; }
-        /// <summary>
-        /// The ability the Pokémon is known to have.
-        /// </summary>
+        /// <summary>The ability the Pokémon is known to have.</summary>
         public PBEAbility KnownAbility { get; set; }
-        /// <summary>
-        /// The Pokémon's gender.
-        /// </summary>
+        /// <summary>The Pokémon's gender.</summary>
         public PBEGender Gender { get; set; }
-        /// <summary>
-        /// The gender the Pokémon looks like (affected by transforming and disguising).
-        /// </summary>
+        /// <summary>The gender the Pokémon looks like (affected by transforming and disguising).</summary>
         public PBEGender KnownGender { get; set; }
-        /// <summary>
-        /// The Pokémon's current item.
-        /// </summary>
+        /// <summary>The Pokémon's current item.</summary>
         public PBEItem Item { get; set; }
-        /// <summary>
-        /// The item the Pokémon is known to have.
-        /// </summary>
+        /// <summary>The item the Pokémon had upon entering battle.</summary>
+        public PBEItem OriginalItem { get; set; }
+        /// <summary>The item the Pokémon is known to have.</summary>
         public PBEItem KnownItem { get; set; }
-        /// <summary>
-        /// The moves the Pokémon currently has.
-        /// </summary>
+        /// <summary>The moves the Pokémon currently has.</summary>
         public PBEMove[] Moves { get; set; }
-        /// <summary>
-        /// The moves the Pokémon is known to have.
-        /// </summary>
+        /// <summary>The moves the Pokémon is known to have.</summary>
         public PBEMove[] KnownMoves { get; set; }
         public byte[] PP { get; set; }
         public byte[] MaxPP { get; set; }
-        /// <summary>
-        /// The nickname the Pokémon normally has.
-        /// </summary>
+        /// <summary>The nickname the Pokémon normally has.</summary>
         public string Nickname { get; set; }
-        /// <summary>
-        /// The nickname the Pokémon is known to have.
-        /// </summary>
+        /// <summary>The nickname the Pokémon is known to have.</summary>
         public string KnownNickname { get; set; }
-        /// <summary>
-        /// The shininess the Pokémon normally has.
-        /// </summary>
+        /// <summary>The shininess the Pokémon normally has.</summary>
         public bool Shiny { get; set; }
-        /// <summary>
-        /// The shininess everyone sees the Pokémon has.
-        /// </summary>
+        /// <summary>The shininess everyone sees the Pokémon has.</summary>
         public bool KnownShiny { get; set; }
-        /// <summary>
-        /// The current species of the Pokémon (affected by transforming or form changing).
-        /// </summary>
+        /// <summary>The current species of the Pokémon (affected by transforming and form changing).</summary>
         public PBESpecies Species { get; set; }
-        /// <summary>
-        /// The species the Pokémon normally is.
-        /// </summary>
+        /// <summary>The species the Pokémon was upon entering battle.</summary>
         public PBESpecies OriginalSpecies { get; set; }
-        /// <summary>
-        /// The species everyone sees the Pokémon as (affected by transforming, disguising, or form changing).
-        /// </summary>
+        /// <summary>The species everyone sees the Pokémon as (affected by transforming, disguising, and form changing).</summary>
         public PBESpecies KnownSpecies { get; set; }
         public PBEStatus1 Status1 { get; set; }
         public PBEStatus2 Status2 { get; set; }
-        /// <summary>
-        /// The Pokémon's first type.
-        /// </summary>
+        /// <summary>The Pokémon's first type.</summary>
         public PBEType Type1 { get; set; }
-        /// <summary>
-        /// The first type everyone believes the Pokémon has.
-        /// </summary>
+        /// <summary>The first type everyone believes the Pokémon has.</summary>
         public PBEType KnownType1 { get; set; }
-        /// <summary>
-        /// The Pokémon's second type.
-        /// </summary>
+        /// <summary>The Pokémon's second type.</summary>
         public PBEType Type2 { get; set; }
-        /// <summary>
-        /// The second type everyone believes the Pokémon has.
-        /// </summary>
+        /// <summary>The second type everyone believes the Pokémon has.</summary>
         public PBEType KnownType2 { get; set; }
         public double Weight { get; set; }
         public double KnownWeight { get; set; }
@@ -255,38 +206,43 @@ namespace Kermalis.PokemonBattleEngine.Battle
         public bool SpeedBoost_AbleToSpeedBoostThisTurn { get; set; }
         #endregion
 
-        // Stats & PP are set from the shell info
-        internal PBEPokemon(PBETeam team, byte id, PBEPokemonShell shell)
+        internal PBEPokemon(BinaryReader r, PBETeam team)
         {
             Team = team;
-            SelectedAction.PokemonId = Id = id;
-            Shell = shell;
-            Ability = OriginalAbility = Shell.Ability;
+            SelectedAction.PokemonId = Id = r.ReadByte();
+            Species = OriginalSpecies = KnownSpecies = (PBESpecies)r.ReadUInt32();
+            var pData = PBEPokemonData.GetData(Species);
+            KnownType1 = Type1 = pData.Type1;
+            KnownType2 = Type2 = pData.Type2;
+            KnownWeight = Weight = pData.Weight;
+            Nickname = KnownNickname = PBEUtils.StringFromBytes(r);
+            Level = r.ReadByte();
+            Friendship = r.ReadByte();
+            Shiny = KnownShiny = r.ReadBoolean();
+            Ability = OriginalAbility = (PBEAbility)r.ReadByte();
             KnownAbility = PBEAbility.MAX;
-            Gender = KnownGender = Shell.Gender;
-            Item = Shell.Item;
+            Nature = (PBENature)r.ReadByte();
+            Gender = KnownGender = (PBEGender)r.ReadByte();
+            Item = OriginalItem = (PBEItem)r.ReadUInt16();
             KnownItem = (PBEItem)ushort.MaxValue;
-            Moves = Shell.Moveset.MoveSlots.Select(m => m.Move).ToArray();
+            EffortValues = new PBEEffortValueCollection(team.Battle.Settings, r.ReadByte(), r.ReadByte(), r.ReadByte(), r.ReadByte(), r.ReadByte(), r.ReadByte());
+            IndividualValues = new PBEIndividualValueCollection(team.Battle.Settings, r.ReadByte(), r.ReadByte(), r.ReadByte(), r.ReadByte(), r.ReadByte(), r.ReadByte());
+            SetStats();
+            HP = MaxHP;
+            HPPercentage = 1D;
+            OriginalMoves = new PBEMove[team.Battle.Settings.NumMoves];
+            OriginalPPUps = new byte[team.Battle.Settings.NumMoves];
+            for (int i = 0; i < team.Battle.Settings.NumMoves; i++)
+            {
+                OriginalMoves[i] = (PBEMove)r.ReadUInt16();
+                OriginalPPUps[i] = r.ReadByte();
+            }
+            Moves = (PBEMove[])OriginalMoves.Clone();
             KnownMoves = new PBEMove[Team.Battle.Settings.NumMoves];
             for (int i = 0; i < Team.Battle.Settings.NumMoves; i++)
             {
                 KnownMoves[i] = PBEMove.MAX;
             }
-            Nickname = KnownNickname = Shell.Nickname;
-            Shiny = KnownShiny = Shell.Shiny;
-            Species = OriginalSpecies = KnownSpecies = Shell.Species;
-            var pData = PBEPokemonData.GetData(Species);
-            KnownType1 = Type1 = pData.Type1;
-            KnownType2 = Type2 = pData.Type2;
-            KnownWeight = Weight = pData.Weight;
-            EffortValues = new PBEEffortValueCollection(team.Battle.Settings, shell.EffortValues);
-            IndividualValues = new PBEIndividualValueCollection(team.Battle.Settings, shell.IndividualValues);
-            Friendship = Shell.Friendship;
-            Level = Shell.Level;
-            Nature = Shell.Nature;
-            SetStats();
-            HP = MaxHP;
-            HPPercentage = 1.0;
             PP = new byte[team.Battle.Settings.NumMoves];
             MaxPP = new byte[team.Battle.Settings.NumMoves];
             for (int i = 0; i < team.Battle.Settings.NumMoves; i++)
@@ -295,7 +251,53 @@ namespace Kermalis.PokemonBattleEngine.Battle
                 if (move != PBEMove.None)
                 {
                     byte tier = PBEMoveData.Data[move].PPTier;
-                    PP[i] = MaxPP[i] = (byte)Math.Max(1, (tier * team.Battle.Settings.PPMultiplier) + (tier * Shell.Moveset.MoveSlots[i].PPUps));
+                    PP[i] = MaxPP[i] = (byte)Math.Max(1, (tier * team.Battle.Settings.PPMultiplier) + (tier * OriginalPPUps[i]));
+                }
+            }
+            team.Party.Add(this);
+        }
+        // Stats & PP are set from the shell info
+        internal PBEPokemon(PBETeam team, byte id, PBEPokemonShell shell)
+        {
+            Team = team;
+            SelectedAction.PokemonId = Id = id;
+            Species = OriginalSpecies = KnownSpecies = shell.Species;
+            var pData = PBEPokemonData.GetData(Species);
+            KnownType1 = Type1 = pData.Type1;
+            KnownType2 = Type2 = pData.Type2;
+            KnownWeight = Weight = pData.Weight;
+            Nickname = KnownNickname = shell.Nickname;
+            Level = shell.Level;
+            Friendship = shell.Friendship;
+            Shiny = KnownShiny = shell.Shiny;
+            Ability = OriginalAbility = shell.Ability;
+            KnownAbility = PBEAbility.MAX;
+            Nature = shell.Nature;
+            Gender = KnownGender = shell.Gender;
+            Item = OriginalItem = shell.Item;
+            KnownItem = (PBEItem)ushort.MaxValue;
+            EffortValues = new PBEEffortValueCollection(team.Battle.Settings, shell.EffortValues);
+            IndividualValues = new PBEIndividualValueCollection(team.Battle.Settings, shell.IndividualValues);
+            SetStats();
+            HP = MaxHP;
+            HPPercentage = 1D;
+            OriginalMoves = shell.Moveset.MoveSlots.Select(m => m.Move).ToArray();
+            OriginalPPUps = shell.Moveset.MoveSlots.Select(m => m.PPUps).ToArray();
+            Moves = (PBEMove[])OriginalMoves.Clone();
+            KnownMoves = new PBEMove[Team.Battle.Settings.NumMoves];
+            for (int i = 0; i < Team.Battle.Settings.NumMoves; i++)
+            {
+                KnownMoves[i] = PBEMove.MAX;
+            }
+            PP = new byte[team.Battle.Settings.NumMoves];
+            MaxPP = new byte[team.Battle.Settings.NumMoves];
+            for (int i = 0; i < team.Battle.Settings.NumMoves; i++)
+            {
+                PBEMove move = Moves[i];
+                if (move != PBEMove.None)
+                {
+                    byte tier = PBEMoveData.Data[move].PPTier;
+                    PP[i] = MaxPP[i] = (byte)Math.Max(1, (tier * team.Battle.Settings.PPMultiplier) + (tier * OriginalPPUps[i]));
                 }
             }
             team.Party.Add(this);
@@ -313,7 +315,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
             Level = info.Level;
             KnownAbility = Ability = OriginalAbility = PBEAbility.MAX;
             KnownGender = Gender = info.Gender;
-            KnownItem = Item = (PBEItem)ushort.MaxValue;
+            KnownItem = Item = OriginalItem = (PBEItem)ushort.MaxValue;
             Moves = new PBEMove[Team.Battle.Settings.NumMoves];
             KnownMoves = new PBEMove[Team.Battle.Settings.NumMoves];
             for (int i = 0; i < Team.Battle.Settings.NumMoves; i++)
@@ -342,9 +344,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
             Speed = PBEPokemonData.CalculateStat(PBEStat.Speed, Species, Nature, EffortValues[PBEStat.Speed].Value, IndividualValues[PBEStat.Speed].Value, Level, Team.Battle.Settings);
         }
 
-        /// <summary>
-        /// Sets and clears all information required for switching out.
-        /// </summary>
+        /// <summary>Sets and clears all information required for switching out.</summary>
         public void ClearForSwitch()
         {
             FieldPosition = PBEFieldPosition.None;
@@ -426,9 +426,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
             }
         }
 
-        /// <summary>
-        /// Transforms into <paramref name="target"/> and sets <see cref="PBEStatus2.Transformed"/>.
-        /// </summary>
+        /// <summary>Transforms into <paramref name="target"/> and sets <see cref="PBEStatus2.Transformed"/>.</summary>
         /// <param name="target">The Pokémon to transform into.</param>
         /// <remarks>Frees the Pokémon of its <see cref="ChoiceLockedMove"/>.</remarks>
         public void Transform(PBEPokemon target)
@@ -492,9 +490,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
             Status2 |= PBEStatus2.Transformed;
         }
 
-        /// <summary>
-        /// Returns True if the Pokémon has <paramref name="type"/>, False otherwise.
-        /// </summary>
+        /// <summary>Returns True if the Pokémon has <paramref name="type"/>, False otherwise.</summary>
         /// <param name="type">The type to check.</param>
         public bool HasType(PBEType type)
         {
@@ -698,9 +694,6 @@ namespace Kermalis.PokemonBattleEngine.Battle
         {
             return TempLockedMove == PBEMove.None;
         }
-        /// <summary>
-        /// Returns True if the Pokémon can become <see cref="PBEStatus2.Infatuated"/> with <paramref name="other"/>.
-        /// </summary>
         // TODO: Make different public versions that use Known*? AIs should not be able to cheat
         public bool CanBecomeBurnedBy(PBEPokemon other)
         {
@@ -719,6 +712,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
                 && !HasType(PBEType.Ice)
                 && !(Ability == PBEAbility.MagmaArmor && !other.HasCancellingAbility());
         }
+        /// <summary>Returns True if the Pokémon can become <see cref="PBEStatus2.Infatuated"/> with <paramref name="other"/>.</summary>
         public bool CanBecomeInfatuatedWith(PBEPokemon other)
         {
             return !Status2.HasFlag(PBEStatus2.Infatuated)
@@ -747,9 +741,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
             return !Status2.HasFlag(PBEStatus2.Flinching)
                 && !(Ability == PBEAbility.InnerFocus && !other.HasCancellingAbility());
         }
-        /// <summary>
-        /// Returns an array of moves the Pokémon can use.
-        /// </summary>
+        /// <summary>Returns an array of moves the Pokémon can use.</summary>
         public PBEMove[] GetUsableMoves()
         {
             var usableMoves = new List<PBEMove>(Team.Battle.Settings.NumMoves);
@@ -777,9 +769,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
             }
             return usableMoves.ToArray();
         }
-        /// <summary>
-        /// Gets the chance of a protection move succeeding, out of <see cref="ushort.MaxValue"/>.
-        /// </summary>
+        /// <summary>Gets the chance of a protection move succeeding, out of <see cref="ushort.MaxValue"/>.</summary>
         public ushort GetProtectionChance()
         {
             ushort chance = ushort.MaxValue;
@@ -798,17 +788,27 @@ namespace Kermalis.PokemonBattleEngine.Battle
             return chance;
         }
 
-        // ToBytes() and FromBytes() will only be used when the server sends you your team Ids, so they do not need to contain all info
         internal List<byte> ToBytes()
         {
             var bytes = new List<byte>();
             bytes.Add(Id);
-            bytes.AddRange(Shell.ToBytes());
+            bytes.AddRange(BitConverter.GetBytes((uint)OriginalSpecies));
+            bytes.AddRange(PBEUtils.StringToBytes(Nickname));
+            bytes.Add(Level);
+            bytes.Add(Friendship);
+            bytes.Add((byte)(Shiny ? 1 : 0));
+            bytes.Add((byte)OriginalAbility);
+            bytes.Add((byte)Nature);
+            bytes.Add((byte)Gender);
+            bytes.AddRange(BitConverter.GetBytes((ushort)OriginalItem));
+            bytes.AddRange(EffortValues.Select(ev => ev.Value));
+            bytes.AddRange(IndividualValues.Select(iv => iv.Value));
+            for (int i = 0; i < Team.Battle.Settings.NumMoves; i++)
+            {
+                bytes.AddRange(BitConverter.GetBytes((ushort)OriginalMoves[i]));
+                bytes.Add(OriginalPPUps[i]);
+            }
             return bytes;
-        }
-        internal static PBEPokemon FromBytes(BinaryReader r, PBETeam team)
-        {
-            return new PBEPokemon(team, r.ReadByte(), PBEPokemonShell.FromBytes(r, team.Battle.Settings));
         }
 
         // Will only be accurate for the host

--- a/PokemonBattleEngine/Battle/Team.cs
+++ b/PokemonBattleEngine/Battle/Team.cs
@@ -13,7 +13,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
         /// <summary>The battle this team and its party belongs to.</summary>
         public PBEBattle Battle { get; }
         public byte Id { get; }
-        public string TrainerName { get; set; }
+        public string TrainerName { get; private set; }
         public List<PBEPokemon> Party { get; private set; }
 
         public IEnumerable<PBEPokemon> ActiveBattlers => Battle.ActiveBattlers.Where(p => p.Team == this).OrderBy(p => p.FieldPosition);
@@ -33,11 +33,11 @@ namespace Kermalis.PokemonBattleEngine.Battle
         public bool MonFaintedLastTurn { get; set; }
         public bool MonFaintedThisTurn { get; set; }
 
-        internal PBETeam(PBEBattle battle, byte id, PBETeamShell shell, ref byte pkmnIdCounter)
+        internal PBETeam(PBEBattle battle, byte id, PBETeamShell shell, string trainerName, ref byte pkmnIdCounter)
         {
             Battle = battle;
             Id = id;
-            CreateParty(shell, ref pkmnIdCounter);
+            CreateParty(shell, trainerName, ref pkmnIdCounter);
         }
         internal PBETeam(PBEBattle battle, byte id)
         {
@@ -45,8 +45,9 @@ namespace Kermalis.PokemonBattleEngine.Battle
             Id = id;
             Party = new List<PBEPokemon>(Battle.Settings.MaxPartySize);
         }
-        internal void CreateParty(PBETeamShell shell, ref byte pkmnIdCounter)
+        internal void CreateParty(PBETeamShell shell, string trainerName, ref byte pkmnIdCounter)
         {
+            TrainerName = trainerName;
             Party = new List<PBEPokemon>(Battle.Settings.MaxPartySize);
             for (int i = 0; i < shell.Count; i++)
             {

--- a/PokemonBattleEngine/Battle/Team.cs
+++ b/PokemonBattleEngine/Battle/Team.cs
@@ -33,14 +33,12 @@ namespace Kermalis.PokemonBattleEngine.Battle
         public bool MonFaintedLastTurn { get; set; }
         public bool MonFaintedThisTurn { get; set; }
 
-        // Host constructor
         internal PBETeam(PBEBattle battle, byte id, PBETeamShell shell, ref byte pkmnIdCounter)
         {
             Battle = battle;
             Id = id;
             CreateParty(shell, ref pkmnIdCounter);
         }
-        // Client constructor
         internal PBETeam(PBEBattle battle, byte id)
         {
             Battle = battle;
@@ -56,18 +54,17 @@ namespace Kermalis.PokemonBattleEngine.Battle
             }
         }
 
-        /// <summary>
-        /// Gets a specific active Pokémon by its position.
-        /// </summary>
-        /// <param name="pos">The position of the Pokémon you want to get.</param>
-        /// <returns>null if no Pokémon was found was found at <paramref name="pos"/>; otherwise the <see cref="PBEPokemon"/>.</returns>
+        /// <summary>Gets a specific active <see cref="PBEPokemon"/> by its <see cref="PBEPokemon.FieldPosition"/>.</summary>
+        /// <param name="pos">The <see cref="PBEFieldPosition"/> of the <see cref="PBEPokemon"/>.</param>
         public PBEPokemon TryGetPokemon(PBEFieldPosition pos)
         {
             return ActiveBattlers.SingleOrDefault(p => p.FieldPosition == pos);
         }
-        public PBEPokemon TryGetPokemon(byte id)
+        /// <summary>Gets a specific <see cref="PBEPokemon"/> by its ID.</summary>
+        /// <param name="pkmnId">The ID of the <see cref="PBEPokemon"/>.</param>
+        public PBEPokemon TryGetPokemon(byte pkmnId)
         {
-            return Party.SingleOrDefault(p => p.Id == id);
+            return Party.SingleOrDefault(p => p.Id == pkmnId);
         }
 
         internal List<byte> ToBytes()

--- a/PokemonBattleEngine/Battle/Team.cs
+++ b/PokemonBattleEngine/Battle/Team.cs
@@ -13,7 +13,7 @@ namespace Kermalis.PokemonBattleEngine.Battle
         /// <summary>The battle this team and its party belongs to.</summary>
         public PBEBattle Battle { get; }
         public byte Id { get; }
-        public string TrainerName { get; private set; }
+        public string TrainerName { get; set; } // Setter is public because a client cannot submit the opponent's team
         public List<PBEPokemon> Party { get; private set; }
 
         public IEnumerable<PBEPokemon> ActiveBattlers => Battle.ActiveBattlers.Where(p => p.Team == this).OrderBy(p => p.FieldPosition);

--- a/PokemonBattleEngine/Data/EventPokemon.cs
+++ b/PokemonBattleEngine/Data/EventPokemon.cs
@@ -1,9 +1,7 @@
-﻿using Kermalis.PokemonBattleEngine.Data;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 
-namespace Kermalis.PokemonBattleEngine
+namespace Kermalis.PokemonBattleEngine.Data
 {
     public sealed class PBEEventPokemon
     {
@@ -30,40 +28,6 @@ namespace Kermalis.PokemonBattleEngine
                 PossibleNatures = new ReadOnlyCollection<PBENature>(possibleNatures);
             }
             IndividualValues = new ReadOnlyCollection<byte?>(ivs); Moves = new ReadOnlyCollection<PBEMove>(moves);
-        }
-
-        /// <summary>Converts the <see cref="PBEEventPokemon"/> into a <see cref="PBEPokemonShell"/> using <see cref="PBESettings.DefaultSettings"/>.</summary>
-        public PBEPokemonShell ToPokemonShell()
-        {
-            PBESettings settings = PBESettings.DefaultSettings;
-            var p = new PBEPokemonShell(Species, Level, settings)
-            {
-                Ability = PossibleAbilities.RandomElement(),
-                Nature = PossibleNatures.RandomElement(),
-            };
-            if (Shiny.HasValue)
-            {
-                p.Shiny = Shiny.Value;
-            }
-            if (Gender < PBEGender.MAX)
-            {
-                p.Gender = Gender;
-            }
-            for (int i = 0; i < 6; i++)
-            {
-                byte? b = IndividualValues[i];
-                if (b.HasValue)
-                {
-                    p.IndividualValues[(PBEStat)i].Value = b.Value;
-                }
-            }
-            PBEMove[] moves = Moves.Concat(new PBEMove[settings.NumMoves - Moves.Count]).ToArray(); // Fills the empty slots with PBEMove.None (Can remove once all moves are added)
-            p.Moveset.Clear();
-            for (int i = 0; i < settings.NumMoves; i++)
-            {
-                p.Moveset.Set(i, moves[i], (byte)PBEUtils.RandomInt(0, settings.MaxPPUps));
-            }
-            return p;
         }
 
         public static ReadOnlyDictionary<PBESpecies, ReadOnlyCollection<PBEEventPokemon>> Events { get; } = new ReadOnlyDictionary<PBESpecies, ReadOnlyCollection<PBEEventPokemon>>(new Dictionary<PBESpecies, ReadOnlyCollection<PBEEventPokemon>>

--- a/PokemonBattleEngine/Data/MoveData.cs
+++ b/PokemonBattleEngine/Data/MoveData.cs
@@ -34,7 +34,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             sb.AppendLine($"Type: {Type}");
             sb.AppendLine($"Category: {Category}");
             sb.AppendLine($"Priority: {Priority}");
-            sb.AppendLine($"PP: {Math.Max(1, PPTier * PBESettings.DefaultSettings.PPMultiplier)}");
+            sb.AppendLine($"PP: {Math.Max(1, PPTier * PBESettings.DefaultPPMultiplier)}");
             sb.AppendLine($"Power: {(Power == 0 ? "--" : Power.ToString())}");
             sb.AppendLine($"Accuracy: {(Accuracy == 0 ? "--" : Accuracy.ToString())}");
             sb.AppendLine($"Effect: {Effect}");

--- a/PokemonBattleEngine/Data/MovesetBuilder.cs
+++ b/PokemonBattleEngine/Data/MovesetBuilder.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Kermalis.PokemonBattleEngine.Data
 {
-    // TODO: Set settings and listen for changes
+    // TODO: Listen for changes to settings
     public sealed class PBEMovesetBuilder : INotifyPropertyChanged
     {
         public sealed class PBEMoveSlot : INotifyPropertyChanged

--- a/PokemonBattleEngine/Data/PBEList.cs
+++ b/PokemonBattleEngine/Data/PBEList.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 
 namespace Kermalis.PokemonBattleEngine.Data
 {
-    public sealed class PBEReadOnlyObservableCollection<T> : IReadOnlyList<T>, INotifyCollectionChanged, INotifyPropertyChanged
+    public sealed class PBEList<T> : IReadOnlyList<T>, INotifyCollectionChanged, INotifyPropertyChanged
     {
         private void FireEvents(NotifyCollectionChangedEventArgs e)
         {
@@ -29,9 +29,13 @@ namespace Kermalis.PokemonBattleEngine.Data
         public int Count => list.Count;
         public T this[int index] => list[index];
 
-        internal PBEReadOnlyObservableCollection()
+        internal PBEList()
         {
             list = new List<T>();
+        }
+        internal PBEList(int capacity)
+        {
+            list = new List<T>(capacity);
         }
 
         internal void Add(T item)
@@ -55,6 +59,19 @@ namespace Kermalis.PokemonBattleEngine.Data
                 FireEvents(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
             }
             return b;
+        }
+        internal void RemoveAt(int index)
+        {
+            if (index < 0 || index >= list.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+            else
+            {
+                T item = list[index];
+                list.RemoveAt(index);
+                FireEvents(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+            }
         }
         internal void Reset(IEnumerable<T> collection)
         {

--- a/PokemonBattleEngine/Data/PokemonData.cs
+++ b/PokemonBattleEngine/Data/PokemonData.cs
@@ -504,7 +504,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             {
                 case PBEStat.HP:
                 {
-                    return (ushort)(species == PBESpecies.Shedinja ? 1 : ((((2 * GetData(species).BaseStats[0]) + ivs + (evs / 4)) * level / settings.MaxLevel) + level + 10));
+                    return (ushort)(species == PBESpecies.Shedinja ? 1 : ((((2 * GetData(species).BaseStats[0]) + ivs + (evs / 4)) * level / 100) + level + 10));
                 }
                 case PBEStat.Attack:
                 case PBEStat.Defense:
@@ -514,7 +514,7 @@ namespace Kermalis.PokemonBattleEngine.Data
                 {
                     int statIndex = (int)stat;
                     double natureMultiplier = 1.0 + (NatureBoosts[nature][statIndex - 1] * settings.NatureStatBoost);
-                    return (ushort)(((((2 * GetData(species).BaseStats[statIndex]) + ivs + (evs / 4)) * level / settings.MaxLevel) + 5) * natureMultiplier);
+                    return (ushort)(((((2 * GetData(species).BaseStats[statIndex]) + ivs + (evs / 4)) * level / 100) + 5) * natureMultiplier);
                 }
                 default: throw new ArgumentOutOfRangeException(nameof(stat));
             }

--- a/PokemonBattleEngine/Data/PokemonShell.cs
+++ b/PokemonBattleEngine/Data/PokemonShell.cs
@@ -22,7 +22,7 @@ namespace Kermalis.PokemonBattleEngine.Data
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private readonly PBESettings settings;
+        private readonly PBETeamShell parent;
 
         private PBEPokemonData pData;
         public ReadOnlyCollection<PBEAbility> SelectableAbilities { get; private set; }
@@ -55,7 +55,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             {
                 if (nickname != value)
                 {
-                    ValidateNickname(value, settings);
+                    ValidateNickname(value, parent.Settings);
                     nickname = value;
                     OnPropertyChanged(nameof(Nickname));
                 }
@@ -69,7 +69,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             {
                 if (level != value)
                 {
-                    ValidateLevel(value, settings);
+                    ValidateLevel(value, parent.Settings);
                     level = value;
                     OnPropertyChanged(nameof(Level));
                     Moveset.Level = value;
@@ -162,26 +162,146 @@ namespace Kermalis.PokemonBattleEngine.Data
         public PBEIndividualValueCollection IndividualValues { get; private set; }
         public PBEMovesetBuilder Moveset { get; private set; }
 
-        private PBEPokemonShell(PBESettings settings)
+        internal PBEPokemonShell(BinaryReader r, PBETeamShell parent)
         {
-            this.settings = settings;
-        }
-        public PBEPokemonShell(PBESpecies species, byte level, PBESettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-            ValidateLevel(level, settings);
+            this.parent = parent;
+            var species = (PBESpecies)r.ReadUInt32();
             ValidateSpecies(species);
-            this.settings = settings;
+            this.species = species;
+            SetSelectable();
+            string nickname = PBEUtils.StringFromBytes(r);
+            ValidateNickname(nickname, parent.Settings);
+            this.nickname = nickname;
+            byte level = r.ReadByte();
+            ValidateLevel(level, parent.Settings);
+            this.level = level;
+            friendship = r.ReadByte();
+            shiny = r.ReadBoolean();
+            var ability = (PBEAbility)r.ReadByte();
+            ValidateAbility(ability);
+            this.ability = ability;
+            var nature = (PBENature)r.ReadByte();
+            ValidateNature(nature);
+            this.nature = nature;
+            var gender = (PBEGender)r.ReadByte();
+            ValidateGender(gender);
+            this.gender = gender;
+            var item = (PBEItem)r.ReadUInt16();
+            ValidateItem(item);
+            this.item = item;
+            byte hpEV = r.ReadByte();
+            byte attackEV = r.ReadByte();
+            byte defenseEV = r.ReadByte();
+            byte spAttackEV = r.ReadByte();
+            byte spDefenseEV = r.ReadByte();
+            byte speedEV = r.ReadByte();
+            if (hpEV + attackEV + defenseEV + spAttackEV + spDefenseEV + speedEV > parent.Settings.MaxTotalEVs)
+            {
+                throw new ArgumentOutOfRangeException(nameof(EffortValues), $"Total must not exceed \"{nameof(parent.Settings.MaxTotalEVs)}\" ({parent.Settings.MaxTotalEVs})");
+            }
+            EffortValues = new PBEEffortValueCollection(parent.Settings, hpEV, attackEV, defenseEV, spAttackEV, spDefenseEV, speedEV);
+            void ValidateIV(byte val, string name)
+            {
+                if (val > parent.Settings.MaxIVs)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(IndividualValues), $"\"{name}\" value must not exceed \"{nameof(parent.Settings.MaxIVs)}\" ({parent.Settings.MaxIVs})");
+                }
+            }
+            byte hpIV = r.ReadByte();
+            ValidateIV(hpIV, nameof(PBEStat.HP));
+            byte attackIV = r.ReadByte();
+            ValidateIV(attackIV, nameof(PBEStat.Attack));
+            byte defenseIV = r.ReadByte();
+            ValidateIV(defenseIV, nameof(PBEStat.Defense));
+            byte spAttackIV = r.ReadByte();
+            ValidateIV(spAttackIV, nameof(PBEStat.SpAttack));
+            byte spDefenseIV = r.ReadByte();
+            ValidateIV(spDefenseIV, nameof(PBEStat.SpDefense));
+            byte speedIV = r.ReadByte();
+            ValidateIV(speedIV, nameof(PBEStat.Speed));
+            IndividualValues = new PBEIndividualValueCollection(parent.Settings, hpIV, attackIV, defenseIV, spAttackIV, spDefenseIV, speedIV);
+            Moveset = new PBEMovesetBuilder(species, level, parent.Settings, false);
+            for (int i = 0; i < parent.Settings.NumMoves; i++)
+            {
+                var move = (PBEMove)r.ReadUInt16();
+                byte ppUps = r.ReadByte();
+                Moveset.Set(i, move, ppUps); // "Set()" will throw its own exceptions for invalid moves and pp-ups
+                                             // The following check is for the case where identical moves were stored in the same moveset, therefore forcing "Set()" to overwrite one with PBEMove.None
+                PBEMovesetBuilder.PBEMoveSlot slot = Moveset.MoveSlots[i];
+                if (slot.Move != move || slot.PPUps != ppUps)
+                {
+                    throw new InvalidDataException("Invalid moveset.");
+                }
+            }
+        }
+        internal PBEPokemonShell(JToken jObj, PBETeamShell parent)
+        {
+            this.parent = parent;
+            friendship = jObj[nameof(Friendship)].Value<byte>();
+            shiny = jObj[nameof(Shiny)].Value<bool>();
+            byte level = jObj[nameof(Level)].Value<byte>();
+            ValidateLevel(level, parent.Settings);
+            this.level = level;
+            string nickname = jObj[nameof(Nickname)].Value<string>();
+            ValidateNickname(nickname, parent.Settings);
+            this.nickname = nickname;
+            PBENature nature = PBELocalizedString.GetNatureByName(jObj[nameof(Nature)].Value<string>()).Value;
+            ValidateNature(nature);
+            this.nature = nature;
+            PBESpecies species = PBELocalizedString.GetSpeciesByName(jObj[nameof(Species)].Value<string>()).Value;
+            ValidateSpecies(species);
+            this.species = species;
+            SetSelectable();
+            PBEAbility ability = PBELocalizedString.GetAbilityByName(jObj[nameof(Ability)].Value<string>()).Value;
+            ValidateAbility(ability);
+            this.ability = ability;
+            PBEGender gender = PBELocalizedString.GetGenderByName(jObj[nameof(Gender)].Value<string>()).Value;
+            ValidateGender(gender);
+            this.gender = gender;
+            PBEItem item = PBELocalizedString.GetItemByName(jObj[nameof(Item)].Value<string>()).Value;
+            ValidateItem(item);
+            this.item = item;
+            JToken eiObj = jObj[nameof(EffortValues)];
+            EffortValues = new PBEEffortValueCollection(parent.Settings,
+                eiObj[nameof(PBEStat.HP)].Value<byte>(),
+                eiObj[nameof(PBEStat.Attack)].Value<byte>(),
+                eiObj[nameof(PBEStat.Defense)].Value<byte>(),
+                eiObj[nameof(PBEStat.SpAttack)].Value<byte>(),
+                eiObj[nameof(PBEStat.SpDefense)].Value<byte>(),
+                eiObj[nameof(PBEStat.Speed)].Value<byte>()
+            );
+            eiObj = jObj[nameof(IndividualValues)];
+            IndividualValues = new PBEIndividualValueCollection(parent.Settings,
+                eiObj[nameof(PBEStat.HP)].Value<byte>(),
+                eiObj[nameof(PBEStat.Attack)].Value<byte>(),
+                eiObj[nameof(PBEStat.Defense)].Value<byte>(),
+                eiObj[nameof(PBEStat.SpAttack)].Value<byte>(),
+                eiObj[nameof(PBEStat.SpDefense)].Value<byte>(),
+                eiObj[nameof(PBEStat.Speed)].Value<byte>()
+            );
+            var mObj = (JArray)jObj[nameof(Moveset)];
+            Moveset = new PBEMovesetBuilder(species, level, parent.Settings, false);
+            for (int j = 0; j < parent.Settings.NumMoves; j++)
+            {
+                eiObj = mObj[j];
+                Moveset.Set(j,
+                    PBELocalizedString.GetMoveByName(eiObj[nameof(PBEMovesetBuilder.PBEMoveSlot.Move)].Value<string>()).Value,
+                    eiObj[nameof(PBEMovesetBuilder.PBEMoveSlot.PPUps)].Value<byte>()
+                    );
+            }
+        }
+        internal PBEPokemonShell(PBESpecies species, byte level, PBETeamShell parent)
+        {
+            ValidateLevel(level, parent.Settings);
+            ValidateSpecies(species);
+            this.parent = parent;
             this.species = species;
             this.level = level;
             friendship = (byte)PBEUtils.RandomInt(0, byte.MaxValue);
             shiny = PBEUtils.RandomShiny();
             nature = AllNatures.RandomElement();
-            EffortValues = new PBEEffortValueCollection(settings, true);
-            IndividualValues = new PBEIndividualValueCollection(settings, true);
+            EffortValues = new PBEEffortValueCollection(parent.Settings, true);
+            IndividualValues = new PBEIndividualValueCollection(parent.Settings, true);
             OnSpeciesChanged(0);
         }
         private void SetSelectable()
@@ -257,7 +377,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             }
             if (oldSpecies == 0)
             {
-                Moveset = new PBEMovesetBuilder(species, level, settings, true);
+                Moveset = new PBEMovesetBuilder(species, level, parent.Settings, true);
             }
             else
             {
@@ -315,144 +435,6 @@ namespace Kermalis.PokemonBattleEngine.Data
             }
         }
 
-        // TODO: Include settings
-        // TODO: Reject team sizes above settings max
-        public static IEnumerable<PBEPokemonShell> TeamFromJsonFile(string path)
-        {
-            var json = JObject.Parse(File.ReadAllText(path));
-            PBESettings settings = PBESettings.DefaultSettings;
-            var partyObject = (JArray)json["Party"];
-            var party = new PBEPokemonShell[partyObject.Count];
-            for (int i = 0; i < party.Length; i++)
-            {
-                JToken pkmnObject = partyObject[i];
-                var pkmn = new PBEPokemonShell(settings)
-                {
-                    friendship = pkmnObject[nameof(Friendship)].Value<byte>(),
-                    shiny = pkmnObject[nameof(Shiny)].Value<bool>()
-                };
-                byte level = pkmnObject[nameof(Level)].Value<byte>();
-                ValidateLevel(level, settings);
-                pkmn.level = level;
-                string nickname = pkmnObject[nameof(Nickname)].Value<string>();
-                ValidateNickname(nickname, settings);
-                pkmn.nickname = nickname;
-                PBENature nature = PBELocalizedString.GetNatureByName(pkmnObject[nameof(Nature)].Value<string>()).Value;
-                ValidateNature(nature);
-                pkmn.nature = nature;
-                PBESpecies species = PBELocalizedString.GetSpeciesByName(pkmnObject[nameof(Species)].Value<string>()).Value;
-                ValidateSpecies(species);
-                pkmn.species = species;
-                pkmn.SetSelectable();
-                PBEAbility ability = PBELocalizedString.GetAbilityByName(pkmnObject[nameof(Ability)].Value<string>()).Value;
-                pkmn.ValidateAbility(ability);
-                pkmn.ability = ability;
-                PBEGender gender = PBELocalizedString.GetGenderByName(pkmnObject[nameof(Gender)].Value<string>()).Value;
-                pkmn.ValidateGender(gender);
-                pkmn.gender = gender;
-                PBEItem item = PBELocalizedString.GetItemByName(pkmnObject[nameof(Item)].Value<string>()).Value;
-                pkmn.ValidateItem(item);
-                pkmn.item = item;
-                JToken wObject = pkmnObject[nameof(EffortValues)];
-                pkmn.EffortValues = new PBEEffortValueCollection(settings,
-                    wObject[nameof(PBEStat.HP)].Value<byte>(),
-                    wObject[nameof(PBEStat.Attack)].Value<byte>(),
-                    wObject[nameof(PBEStat.Defense)].Value<byte>(),
-                    wObject[nameof(PBEStat.SpAttack)].Value<byte>(),
-                    wObject[nameof(PBEStat.SpDefense)].Value<byte>(),
-                    wObject[nameof(PBEStat.Speed)].Value<byte>()
-                );
-                wObject = pkmnObject[nameof(IndividualValues)];
-                pkmn.IndividualValues = new PBEIndividualValueCollection(settings,
-                    wObject[nameof(PBEStat.HP)].Value<byte>(),
-                    wObject[nameof(PBEStat.Attack)].Value<byte>(),
-                    wObject[nameof(PBEStat.Defense)].Value<byte>(),
-                    wObject[nameof(PBEStat.SpAttack)].Value<byte>(),
-                    wObject[nameof(PBEStat.SpDefense)].Value<byte>(),
-                    wObject[nameof(PBEStat.Speed)].Value<byte>()
-                );
-                var mObject = (JArray)pkmnObject[nameof(Moveset)];
-                pkmn.Moveset = new PBEMovesetBuilder(pkmn.species, pkmn.level, settings, false);
-                for (int j = 0; j < settings.NumMoves; j++)
-                {
-                    wObject = mObject[j];
-                    pkmn.Moveset.Set(j,
-                        PBELocalizedString.GetMoveByName(wObject[nameof(PBEMovesetBuilder.PBEMoveSlot.Move)].Value<string>()).Value,
-                        wObject[nameof(PBEMovesetBuilder.PBEMoveSlot.PPUps)].Value<byte>()
-                        );
-                }
-                party[i] = pkmn;
-            }
-            return party;
-        }
-        // TODO: Include settings
-        // TODO: Reject team sizes above settings max
-        public static void TeamToJsonFile(string path, IEnumerable<PBEPokemonShell> party)
-        {
-            using (var writer = new JsonTextWriter(File.CreateText(path)) { Formatting = Formatting.Indented })
-            {
-                writer.WriteStartObject();
-                writer.WritePropertyName("Party");
-                writer.WriteStartArray();
-                PBEPokemonShell[] p = party.ToArray();
-                byte amt = (byte)p.Length;
-                for (int i = 0; i < amt; i++)
-                {
-                    PBEPokemonShell pkmn = p[i];
-                    writer.WriteStartObject();
-                    writer.WritePropertyName(nameof(Species));
-                    writer.WriteValue(pkmn.species.ToString());
-                    writer.WritePropertyName(nameof(Nickname));
-                    writer.WriteValue(pkmn.nickname);
-                    writer.WritePropertyName(nameof(Level));
-                    writer.WriteValue(pkmn.level);
-                    writer.WritePropertyName(nameof(Friendship));
-                    writer.WriteValue(pkmn.friendship);
-                    writer.WritePropertyName(nameof(Shiny));
-                    writer.WriteValue(pkmn.shiny);
-                    writer.WritePropertyName(nameof(Ability));
-                    writer.WriteValue(pkmn.ability.ToString());
-                    writer.WritePropertyName(nameof(Nature));
-                    writer.WriteValue(pkmn.nature.ToString());
-                    writer.WritePropertyName(nameof(Gender));
-                    writer.WriteValue(pkmn.gender.ToString());
-                    writer.WritePropertyName(nameof(Item));
-                    writer.WriteValue(pkmn.item.ToString());
-                    writer.WritePropertyName(nameof(EffortValues));
-                    writer.WriteStartObject();
-                    foreach (PBEEffortValueCollection.PBEEffortValue ev in pkmn.EffortValues)
-                    {
-                        writer.WritePropertyName(ev.Stat.ToString());
-                        writer.WriteValue(ev.Value);
-                    }
-                    writer.WriteEndObject();
-                    writer.WritePropertyName(nameof(IndividualValues));
-                    writer.WriteStartObject();
-                    foreach (PBEIndividualValueCollection.PBEIndividualValue iv in pkmn.IndividualValues)
-                    {
-                        writer.WritePropertyName(iv.Stat.ToString());
-                        writer.WriteValue(iv.Value);
-                    }
-                    writer.WriteEndObject();
-                    writer.WritePropertyName(nameof(Moveset));
-                    writer.WriteStartArray();
-                    foreach (PBEMovesetBuilder.PBEMoveSlot slot in pkmn.Moveset.MoveSlots)
-                    {
-                        writer.WriteStartObject();
-                        writer.WritePropertyName(nameof(PBEMovesetBuilder.PBEMoveSlot.Move));
-                        writer.WriteValue(slot.Move.ToString());
-                        writer.WritePropertyName(nameof(PBEMovesetBuilder.PBEMoveSlot.PPUps));
-                        writer.WriteValue(slot.PPUps);
-                        writer.WriteEndObject();
-                    }
-                    writer.WriteEndArray();
-                    writer.WriteEndObject();
-                }
-                writer.WriteEndArray();
-                writer.WriteEndObject();
-            }
-        }
-
         internal List<byte> ToBytes()
         {
             var bytes = new List<byte>();
@@ -474,78 +456,56 @@ namespace Kermalis.PokemonBattleEngine.Data
             }
             return bytes;
         }
-        internal static PBEPokemonShell FromBytes(BinaryReader r, PBESettings settings)
+        internal void ToJson(JsonTextWriter w)
         {
-            var pkmn = new PBEPokemonShell(settings);
-            var species = (PBESpecies)r.ReadUInt32();
-            ValidateSpecies(species);
-            pkmn.species = species;
-            pkmn.SetSelectable();
-            string nickname = PBEUtils.StringFromBytes(r);
-            ValidateNickname(nickname, settings);
-            pkmn.nickname = nickname;
-            byte level = r.ReadByte();
-            ValidateLevel(level, settings);
-            pkmn.level = level;
-            pkmn.friendship = r.ReadByte();
-            pkmn.shiny = r.ReadBoolean();
-            var ability = (PBEAbility)r.ReadByte();
-            pkmn.ValidateAbility(ability);
-            pkmn.ability = ability;
-            var nature = (PBENature)r.ReadByte();
-            ValidateNature(nature);
-            pkmn.nature = nature;
-            var gender = (PBEGender)r.ReadByte();
-            pkmn.ValidateGender(gender);
-            pkmn.gender = gender;
-            var item = (PBEItem)r.ReadUInt16();
-            pkmn.ValidateItem(item);
-            pkmn.item = item;
-            byte hpEV = r.ReadByte();
-            byte attackEV = r.ReadByte();
-            byte defenseEV = r.ReadByte();
-            byte spAttackEV = r.ReadByte();
-            byte spDefenseEV = r.ReadByte();
-            byte speedEV = r.ReadByte();
-            if (hpEV + attackEV + defenseEV + spAttackEV + spDefenseEV + speedEV > settings.MaxTotalEVs)
+            w.WriteStartObject();
+            w.WritePropertyName(nameof(Species));
+            w.WriteValue(species.ToString());
+            w.WritePropertyName(nameof(Nickname));
+            w.WriteValue(nickname);
+            w.WritePropertyName(nameof(Level));
+            w.WriteValue(level);
+            w.WritePropertyName(nameof(Friendship));
+            w.WriteValue(friendship);
+            w.WritePropertyName(nameof(Shiny));
+            w.WriteValue(shiny);
+            w.WritePropertyName(nameof(Ability));
+            w.WriteValue(ability.ToString());
+            w.WritePropertyName(nameof(Nature));
+            w.WriteValue(nature.ToString());
+            w.WritePropertyName(nameof(Gender));
+            w.WriteValue(gender.ToString());
+            w.WritePropertyName(nameof(Item));
+            w.WriteValue(item.ToString());
+            w.WritePropertyName(nameof(EffortValues));
+            w.WriteStartObject();
+            foreach (PBEEffortValueCollection.PBEEffortValue ev in EffortValues)
             {
-                throw new ArgumentOutOfRangeException(nameof(EffortValues), $"Total must not exceed \"{nameof(settings.MaxTotalEVs)}\" ({settings.MaxTotalEVs})");
+                w.WritePropertyName(ev.Stat.ToString());
+                w.WriteValue(ev.Value);
             }
-            pkmn.EffortValues = new PBEEffortValueCollection(settings, hpEV, attackEV, defenseEV, spAttackEV, spDefenseEV, speedEV);
-            void ValidateIV(byte val, string name)
+            w.WriteEndObject();
+            w.WritePropertyName(nameof(IndividualValues));
+            w.WriteStartObject();
+            foreach (PBEIndividualValueCollection.PBEIndividualValue iv in IndividualValues)
             {
-                if (val > settings.MaxIVs)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(IndividualValues), $"\"{name}\" value must not exceed \"{nameof(settings.MaxIVs)}\" ({settings.MaxIVs})");
-                }
+                w.WritePropertyName(iv.Stat.ToString());
+                w.WriteValue(iv.Value);
             }
-            byte hpIV = r.ReadByte();
-            ValidateIV(hpIV, nameof(PBEStat.HP));
-            byte attackIV = r.ReadByte();
-            ValidateIV(attackIV, nameof(PBEStat.Attack));
-            byte defenseIV = r.ReadByte();
-            ValidateIV(defenseIV, nameof(PBEStat.Defense));
-            byte spAttackIV = r.ReadByte();
-            ValidateIV(spAttackIV, nameof(PBEStat.SpAttack));
-            byte spDefenseIV = r.ReadByte();
-            ValidateIV(spDefenseIV, nameof(PBEStat.SpDefense));
-            byte speedIV = r.ReadByte();
-            ValidateIV(speedIV, nameof(PBEStat.Speed));
-            pkmn.IndividualValues = new PBEIndividualValueCollection(settings, hpIV, attackIV, defenseIV, spAttackIV, spDefenseIV, speedIV);
-            pkmn.Moveset = new PBEMovesetBuilder(species, level, settings, false);
-            for (int i = 0; i < settings.NumMoves; i++)
+            w.WriteEndObject();
+            w.WritePropertyName(nameof(Moveset));
+            w.WriteStartArray();
+            foreach (PBEMovesetBuilder.PBEMoveSlot slot in Moveset.MoveSlots)
             {
-                var move = (PBEMove)r.ReadUInt16();
-                byte ppUps = r.ReadByte();
-                pkmn.Moveset.Set(i, move, ppUps); // "Set()" will throw its own exceptions for invalid moves and pp-ups
-                                                  // The following check is for the case where identical moves were stored in the same moveset, therefore forcing "Set()" to overwrite one with PBEMove.None
-                PBEMovesetBuilder.PBEMoveSlot slot = pkmn.Moveset.MoveSlots[i];
-                if (slot.Move != move || slot.PPUps != ppUps)
-                {
-                    throw new InvalidDataException("Invalid moveset.");
-                }
+                w.WriteStartObject();
+                w.WritePropertyName(nameof(PBEMovesetBuilder.PBEMoveSlot.Move));
+                w.WriteValue(slot.Move.ToString());
+                w.WritePropertyName(nameof(PBEMovesetBuilder.PBEMoveSlot.PPUps));
+                w.WriteValue(slot.PPUps);
+                w.WriteEndObject();
             }
-            return pkmn;
+            w.WriteEndArray();
+            w.WriteEndObject();
         }
     }
 }

--- a/PokemonBattleEngine/Data/PokemonShell.cs
+++ b/PokemonBattleEngine/Data/PokemonShell.cs
@@ -453,7 +453,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             }
         }
 
-        internal byte[] ToBytes()
+        internal List<byte> ToBytes()
         {
             var bytes = new List<byte>();
             bytes.AddRange(BitConverter.GetBytes((uint)species));
@@ -472,7 +472,7 @@ namespace Kermalis.PokemonBattleEngine.Data
                 bytes.AddRange(BitConverter.GetBytes((ushort)slot.Move));
                 bytes.Add(slot.PPUps);
             }
-            return bytes.ToArray();
+            return bytes;
         }
         internal static PBEPokemonShell FromBytes(BinaryReader r, PBESettings settings)
         {

--- a/PokemonBattleEngine/Data/PokemonShell.cs
+++ b/PokemonBattleEngine/Data/PokemonShell.cs
@@ -392,35 +392,29 @@ namespace Kermalis.PokemonBattleEngine.Data
 
         internal void OnSettingsChanged(object sender, PropertyChangedEventArgs e)
         {
-            var settings = (PBESettings)sender;
             switch (e.PropertyName)
             {
-                case nameof(settings.MaxLevel):
+                case nameof(parent.Settings.MaxLevel):
                 {
-                    if (level > settings.MaxLevel)
+                    if (level > parent.Settings.MaxLevel)
                     {
-                        level = settings.MaxLevel;
-                        OnPropertyChanged(nameof(Level));
-                        Moveset.Level = level;
+                        Level = parent.Settings.MaxLevel;
                     }
                     break;
                 }
-                case nameof(settings.MaxPokemonNameLength):
+                case nameof(parent.Settings.MaxPokemonNameLength):
                 {
-                    if (nickname.Length > settings.MaxPokemonNameLength)
+                    if (nickname.Length > parent.Settings.MaxPokemonNameLength)
                     {
-                        nickname = nickname.Substring(0, settings.MaxPokemonNameLength);
-                        OnPropertyChanged(nameof(Nickname));
+                        Nickname = nickname.Substring(0, parent.Settings.MaxPokemonNameLength);
                     }
                     break;
                 }
-                case nameof(settings.MinLevel):
+                case nameof(parent.Settings.MinLevel):
                 {
-                    if (level < settings.MinLevel)
+                    if (level < parent.Settings.MinLevel)
                     {
-                        level = settings.MinLevel;
-                        OnPropertyChanged(nameof(Level));
-                        Moveset.Level = level;
+                        Level = parent.Settings.MinLevel;
                     }
                     break;
                 }

--- a/PokemonBattleEngine/Data/ReadOnlyObservableCollection.cs
+++ b/PokemonBattleEngine/Data/ReadOnlyObservableCollection.cs
@@ -8,6 +8,12 @@ namespace Kermalis.PokemonBattleEngine.Data
 {
     public sealed class PBEReadOnlyObservableCollection<T> : IReadOnlyList<T>, INotifyCollectionChanged, INotifyPropertyChanged
     {
+        private void FireEvents(NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(Count));
+            OnPropertyChanged("Item[]");
+            OnCollectionChanged(e);
+        }
         private void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
             CollectionChanged?.Invoke(this, e);
@@ -26,13 +32,6 @@ namespace Kermalis.PokemonBattleEngine.Data
         internal PBEReadOnlyObservableCollection()
         {
             list = new List<T>();
-        }
-
-        private void FireEvents(NotifyCollectionChangedEventArgs e)
-        {
-            OnPropertyChanged(nameof(Count));
-            OnPropertyChanged("Item[]");
-            OnCollectionChanged(e);
         }
 
         internal void Add(T item)

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 
 namespace Kermalis.PokemonBattleEngine.Data
 {
-    // TODO: .Equals, struct?
+    // TODO: .Equals, ability to make read-only
     /// <summary>The various engine settings.</summary>
     public sealed class PBESettings : INotifyPropertyChanged
     {
@@ -16,9 +16,11 @@ namespace Kermalis.PokemonBattleEngine.Data
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>The default settings used in official games.</summary>
-        public static PBESettings DefaultSettings { get; } = new PBESettings(); // TODO: I wish I could make this constant somehow (it can be edited) (would a struct work?)
+        public static PBESettings DefaultSettings { get; } = new PBESettings();
 
-        private byte maxLevel;
+        /// <summary>The default value of <see cref="MaxLevel"/>.</summary>
+        public const byte DefaultMaxLevel = 100;
+        private byte maxLevel = DefaultMaxLevel;
         /// <summary>The maximum level a Pokémon can be. Used in stat calculation.</summary>
         public byte MaxLevel
         {
@@ -36,7 +38,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte minLevel;
+        /// <summary>The default value of <see cref="MinLevel"/>.</summary>
+        public const byte DefaultMinLevel = 1;
+        private byte minLevel = DefaultMinLevel;
         /// <summary>The minimum level a Pokémon can be.</summary>
         public byte MinLevel
         {
@@ -54,7 +58,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private sbyte maxPartySize;
+        /// <summary>The default value of <see cref="MaxPartySize"/>.</summary>
+        public const sbyte DefaultMaxPartySize = 6;
+        private sbyte maxPartySize = DefaultMaxPartySize;
         /// <summary>The maximum amount of Pokémon each team can bring into a battle.</summary>
         public sbyte MaxPartySize
         {
@@ -72,7 +78,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte maxPokemonNameLength;
+        /// <summary>The default value of <see cref="MaxPokemonNameLength"/>.</summary>
+        public const byte DefaultMaxPokemonNameLength = 10;
+        private byte maxPokemonNameLength = DefaultMaxPokemonNameLength;
         /// <summary>The maximum amount of characters a Pokémon nickname can have.</summary>
         public byte MaxPokemonNameLength
         {
@@ -90,7 +98,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte maxTrainerNameLength;
+        /// <summary>The default value of <see cref="MaxTrainerNameLength"/>. This value is different in non-English games.</summary>
+        public const byte DefaultMaxTrainerNameLength = 7;
+        private byte maxTrainerNameLength = DefaultMaxTrainerNameLength;
         /// <summary>The maximum amount of characters a trainer's name can have.</summary>
         [Obsolete("Currently not used anywhere")]
         public byte MaxTrainerNameLength
@@ -109,7 +119,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private ushort maxTotalEVs;
+        /// <summary>The default value of <see cref="MaxTotalEVs"/>.</summary>
+        public const ushort DefaultMaxTotalEVs = 510;
+        private ushort maxTotalEVs = DefaultMaxTotalEVs;
         /// <summary>The maximum sum of a Pokémon's EVs.</summary>
         public ushort MaxTotalEVs
         {
@@ -128,7 +140,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte maxIVs;
+        /// <summary>The default value of <see cref="MaxIVs"/>.</summary>
+        public const byte DefaultMaxIVs = 31;
+        private byte maxIVs = DefaultMaxIVs;
         /// <summary>The maximum amount of IVs Pokémon can have in each stat. Raising this will not affect <see cref="PBEMove.HiddenPower"/>.</summary>
         public byte MaxIVs
         {
@@ -142,7 +156,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private double natureStatBoost;
+        /// <summary>The default value of <see cref="NatureStatBoost"/>.</summary>
+        public const double DefaultNatureStatBoost = 0.1;
+        private double natureStatBoost = DefaultNatureStatBoost;
         /// <summary>The amount of influence a Pokémon's <see cref="PBENature"/> has on its stats.</summary>
         public double NatureStatBoost
         {
@@ -160,7 +176,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private sbyte maxStatChange;
+        /// <summary>The default value of <see cref="MaxStatChange"/>.</summary>
+        public const sbyte DefaultMaxStatChange = 6;
+        private sbyte maxStatChange = DefaultMaxStatChange;
         /// <summary>The maximum change a stat can have in the negative and positive direction.</summary>
         public sbyte MaxStatChange
         {
@@ -174,7 +192,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte numMoves;
+        /// <summary>The default value of <see cref="NumMoves"/>.</summary>
+        public const byte DefaultNumMoves = 4;
+        private byte numMoves = DefaultNumMoves;
         /// <summary>The maximum amount of moves a specific Pokémon can remember at once.</summary>
         public byte NumMoves
         {
@@ -192,7 +212,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte ppMultiplier;
+        /// <summary>The default value of <see cref="PPMultiplier"/>.</summary>
+        public const byte DefaultPPMultiplier = 5;
+        private byte ppMultiplier = DefaultPPMultiplier;
         /// <summary>This affects the base PP of each move and the boost PP-Ups give.</summary>
         /// <remarks>
         /// <para>Growl is a tier 8 move, so the maximum PP will be 64. The formula: Max(1, ((tier * PPMultiplier) + (tier * PPUps))).</para>
@@ -214,7 +236,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte maxPPUps;
+        /// <summary>The default value of <see cref="MaxPPUps"/>.</summary>
+        public const byte DefaultMaxPPUps = 3;
+        private byte maxPPUps = DefaultMaxPPUps;
         /// <summary>The maximum amount of PP-Ups that can be used on each of a Pokémon's moves.</summary>
         public byte MaxPPUps
         {
@@ -228,7 +252,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private double critMultiplier;
+        /// <summary>The default value of <see cref="CritMultiplier"/>.</summary>
+        public const double DefaultCritMultiplier = 2.0;
+        private double critMultiplier = DefaultCritMultiplier;
         /// <summary>The damage boost awarded by critical hits.</summary>
         public double CritMultiplier
         {
@@ -242,7 +268,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte confusionMinTurns;
+        /// <summary>The default value of <see cref="ConfusionMinTurns"/>.</summary>
+        public const byte DefaultConfusionMinTurns = 1;
+        private byte confusionMinTurns = DefaultConfusionMinTurns;
         /// <summary>The minimum amount of turns a Pokémon can be <see cref="PBEStatus2.Confused"/>.</summary>
         public byte ConfusionMinTurns
         {
@@ -260,7 +288,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte confusionMaxTurns;
+        /// <summary>The default value of <see cref="ConfusionMaxTurns"/>.</summary>
+        public const byte DefaultConfusionMaxTurns = 4;
+        private byte confusionMaxTurns = DefaultConfusionMaxTurns;
         /// <summary>The maximum amount of turns a Pokémon can be <see cref="PBEStatus2.Confused"/>.</summary>
         public byte ConfusionMaxTurns
         {
@@ -278,7 +308,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte sleepMinTurns;
+        /// <summary>The default value of <see cref="SleepMinTurns"/>.</summary>
+        public const byte DefaultSleepMinTurns = 1;
+        private byte sleepMinTurns = DefaultSleepMinTurns;
         /// <summary>The minimum amount of turns a Pokémon can be <see cref="PBEStatus1.Asleep"/>.</summary>
         public byte SleepMinTurns
         {
@@ -296,7 +328,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte sleepMaxTurns;
+        /// <summary>The default value of <see cref="SleepMaxTurns"/>.</summary>
+        public const byte DefaultSleepMaxTurns = 3;
+        private byte sleepMaxTurns = DefaultSleepMaxTurns;
         /// <summary>The maximum amount of turns a Pokémon can be <see cref="PBEStatus1.Asleep"/>.</summary>
         public byte SleepMaxTurns
         {
@@ -314,7 +348,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte burnDamageDenominator;
+        /// <summary>The default value of <see cref="BurnDamageDenominator"/>.</summary>
+        public const byte DefaultBurnDamageDenominator = 8;
+        private byte burnDamageDenominator = DefaultBurnDamageDenominator;
         /// <summary>A Pokémon with <see cref="PBEStatus1.Burned"/> loses (1/this) of its HP at the end of every turn.</summary>
         public byte BurnDamageDenominator
         {
@@ -332,7 +368,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte poisonDamageDenominator;
+        /// <summary>The default value of <see cref="PoisonDamageDenominator"/>.</summary>
+        public const byte DefaultPoisonDamageDenominator = 8;
+        private byte poisonDamageDenominator = DefaultPoisonDamageDenominator;
         /// <summary>A Pokémon with <see cref="PBEStatus1.Poisoned"/> loses (1/this) of its HP at the end of every turn.</summary>
         public byte PoisonDamageDenominator
         {
@@ -350,7 +388,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte toxicDamageDenominator;
+        /// <summary>The default value of <see cref="ToxicDamageDenominator"/>.</summary>
+        public const byte DefaultToxicDamageDenominator = 16;
+        private byte toxicDamageDenominator = DefaultToxicDamageDenominator;
         /// <summary>A Pokémon with <see cref="PBEStatus1.BadlyPoisoned"/> loses (<see cref="PBEPokemon.Status1Counter"/>/this) of its HP at the end of every turn.</summary>
         public byte ToxicDamageDenominator
         {
@@ -368,7 +408,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte leechSeedDenominator;
+        /// <summary>The default value of <see cref="LeechSeedDenominator"/>.</summary>
+        public const byte DefaultLeechSeedDenominator = 8;
+        private byte leechSeedDenominator = DefaultLeechSeedDenominator;
         /// <summary>A Pokémon with <see cref="PBEStatus2.LeechSeed"/> loses (1/this) of its HP at the end of every turn and the Pokémon at <see cref="PBEPokemon.SeededPosition"/> on <see cref="PBEPokemon.SeededTeam"/> restores the lost HP.</summary>
         public byte LeechSeedDenominator
         {
@@ -386,7 +428,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte curseDenominator;
+        /// <summary>The default value of <see cref="CurseDenominator"/>.</summary>
+        public const byte DefaultCurseDenominator = 4;
+        private byte curseDenominator = DefaultCurseDenominator;
         /// <summary>A Pokémon with <see cref="PBEStatus2.Cursed"/> loses (1/this) of its HP at the end of every turn.</summary>
         public byte CurseDenominator
         {
@@ -404,7 +448,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte leftoversHealDenominator;
+        /// <summary>The default value of <see cref="LeftoversHealDenominator"/>.</summary>
+        public const byte DefaultLeftoversHealDenominator = 16;
+        private byte leftoversHealDenominator = DefaultLeftoversHealDenominator;
         /// <summary>A Pokémon holding a <see cref="PBEItem.Leftovers"/> restores (1/this) of its HP at the end of every turn.</summary>
         public byte LeftoversHealDenominator
         {
@@ -422,7 +468,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte blackSludgeDamageDenominator;
+        /// <summary>The default value of <see cref="BlackSludgeDamageDenominator"/>.</summary>
+        public const byte DefaultBlackSludgeDamageDenominator = 8;
+        private byte blackSludgeDamageDenominator = DefaultBlackSludgeDamageDenominator;
         /// <summary>A Pokémon holding a <see cref="PBEItem.BlackSludge"/> without <see cref="PBEType.Poison"/> loses (1/this) of its HP at the end of every turn.</summary>
         public byte BlackSludgeDamageDenominator
         {
@@ -440,7 +488,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte blackSludgeHealDenominator;
+        /// <summary>The default value of <see cref="BlackSludgeHealDenominator"/>.</summary>
+        public const byte DefaultBlackSludgeHealDenominator = 16;
+        private byte blackSludgeHealDenominator = DefaultBlackSludgeHealDenominator;
         /// <summary>A Pokémon holding a <see cref="PBEItem.BlackSludge"/> with <see cref="PBEType.Poison"/> restores (1/this) of its HP at the end of every turn.</summary>
         public byte BlackSludgeHealDenominator
         {
@@ -458,7 +508,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte reflectTurns;
+        /// <summary>The default value of <see cref="ReflectTurns"/>.</summary>
+        public const byte DefaultReflectTurns = 5;
+        private byte reflectTurns = DefaultReflectTurns;
         /// <summary>The amount of turns <see cref="PBEMove.Reflect"/> lasts.</summary>
         public byte ReflectTurns
         {
@@ -476,7 +528,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte lightScreenTurns;
+        /// <summary>The default value of <see cref="LightScreenTurns"/>.</summary>
+        public const byte DefaultLightScreenTurns = 5;
+        private byte lightScreenTurns = DefaultLightScreenTurns;
         /// <summary>The amount of turns <see cref="PBEMove.LightScreen"/> lasts.</summary>
         public byte LightScreenTurns
         {
@@ -494,7 +548,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte lightClayTurnExtension;
+        /// <summary>The default value of <see cref="LightClayTurnExtension"/>.</summary>
+        public const byte DefaultLightClayTurnExtension = 3;
+        private byte lightClayTurnExtension = DefaultLightClayTurnExtension;
         /// <summary>The amount of turns added to <see cref="ReflectTurns"/> and <see cref="LightScreenTurns"/> when the user is holding a <see cref="PBEItem.LightClay"/>.</summary>
         public byte LightClayTurnExtension
         {
@@ -508,7 +564,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte hailTurns;
+        /// <summary>The default value of <see cref="HailTurns"/>.</summary>
+        public const byte DefaultHailTurns = 5;
+        private byte hailTurns = DefaultHailTurns;
         /// <summary>The amount of turns <see cref="PBEWeather.Hailstorm"/> lasts. For infinite turns, set <see cref="IcyRockTurnExtension"/> to 0 first, then this to 0.</summary>
         public byte HailTurns
         {
@@ -526,7 +584,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte hailDamageDenominator;
+        /// <summary>The default value of <see cref="HailDamageDenominator"/>.</summary>
+        public const byte DefaultHailDamageDenominator = 16;
+        private byte hailDamageDenominator = DefaultHailDamageDenominator;
         /// <summary>A Pokémon in <see cref="PBEWeather.Hailstorm"/> loses (1/this) of its HP at the end of every turn.</summary>
         public byte HailDamageDenominator
         {
@@ -544,7 +604,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte icyRockTurnExtension;
+        /// <summary>The default value of <see cref="IcyRockTurnExtension"/>.</summary>
+        public const byte DefaultIcyRockTurnExtension = 3;
+        private byte icyRockTurnExtension = DefaultIcyRockTurnExtension;
         /// <summary>The amount of turns added to <see cref="HailTurns"/> when the user is holding a <see cref="PBEItem.IcyRock"/>. If <see cref="HailTurns"/> is 0 (infinite turns), this must also be 0.</summary>
         public byte IcyRockTurnExtension
         {
@@ -562,7 +624,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte iceBodyHealDenominator;
+        /// <summary>The default value of <see cref="IceBodyHealDenominator"/>.</summary>
+        public const byte DefaultIceBodyHealDenominator = 16;
+        private byte iceBodyHealDenominator = DefaultIceBodyHealDenominator;
         /// <summary>A Pokémon with <see cref="PBEAbility.IceBody"/> in <see cref="PBEWeather.Hailstorm"/> restores (1/this) of its HP at the end of every turn.</summary>
         public byte IceBodyHealDenominator
         {
@@ -580,7 +644,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte rainTurns;
+        /// <summary>The default value of <see cref="RainTurns"/>.</summary>
+        public const byte DefaultRainTurns = 5;
+        private byte rainTurns = DefaultRainTurns;
         /// <summary>The amount of turns <see cref="PBEWeather.Rain"/> lasts. For infinite turns, set <see cref="DampRockTurnExtension"/> to 0 first, then this to 0.</summary>
         public byte RainTurns
         {
@@ -598,7 +664,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte dampRockTurnExtension;
+        /// <summary>The default value of <see cref="DampRockTurnExtension"/>.</summary>
+        public const byte DefaultDampRockTurnExtension = 3;
+        private byte dampRockTurnExtension = DefaultDampRockTurnExtension;
         /// <summary>The amount of turns added to <see cref="RainTurns"/> when the user is holding a <see cref="PBEItem.DampRock"/>. If <see cref="RainTurns"/> is 0 (infinite turns), this must also be 0.</summary>
         public byte DampRockTurnExtension
         {
@@ -616,7 +684,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte sandstormTurns;
+        /// <summary>The default value of <see cref="SandstormTurns"/>.</summary>
+        public const byte DefaultSandstormTurns = 5;
+        private byte sandstormTurns = DefaultSandstormTurns;
         /// <summary>The amount of turns <see cref="PBEWeather.Sandstorm"/> lasts. For infinite turns, set <see cref="SmoothRockTurnExtension"/> to 0 first, then this to 0.</summary>
         public byte SandstormTurns
         {
@@ -634,7 +704,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte sandstormDamageDenominator;
+        /// <summary>The default value of <see cref="SandstormDamageDenominator"/>.</summary>
+        public const byte DefaultSandstormDamageDenominator = 16;
+        private byte sandstormDamageDenominator = DefaultSandstormDamageDenominator;
         /// <summary>A Pokémon in <see cref="PBEWeather.Sandstorm"/> loses (1/this) of its HP at the end of every turn.</summary>
         public byte SandstormDamageDenominator
         {
@@ -652,7 +724,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte smoothRockTurnExtension;
+        /// <summary>The default value of <see cref="SmoothRockTurnExtension"/>.</summary>
+        public const byte DefaultSmoothRockTurnExtension = 3;
+        private byte smoothRockTurnExtension = DefaultSmoothRockTurnExtension;
         /// <summary>The amount of turns added to <see cref="SandstormTurns"/> when the user is holding a <see cref="PBEItem.SmoothRock"/>. If <see cref="SandstormTurns"/> is 0 (infinite turns), this must also be 0.</summary>
         public byte SmoothRockTurnExtension
         {
@@ -670,7 +744,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte sunTurns;
+        /// <summary>The default value of <see cref="SunTurns"/>.</summary>
+        public const byte DefaultSunTurns = 5;
+        private byte sunTurns = DefaultSunTurns;
         /// <summary>The amount of turns <see cref="PBEWeather.HarshSunlight"/> lasts. For infinite turns, set <see cref="HeatRockTurnExtension"/> to 0 first, then this to 0.</summary>
         public byte SunTurns
         {
@@ -688,7 +764,9 @@ namespace Kermalis.PokemonBattleEngine.Data
                 }
             }
         }
-        private byte heatRockTurnExtension;
+        /// <summary>The default value of <see cref="HeatRockTurnExtension"/>.</summary>
+        public const byte DefaultHeatRockTurnExtension = 3;
+        private byte heatRockTurnExtension = DefaultHeatRockTurnExtension;
         /// <summary>The amount of turns added to <see cref="SunTurns"/> when the user is holding a <see cref="PBEItem.HeatRock"/>. If <see cref="SunTurns"/> is 0 (infinite turns), this must also be 0.</summary>
         public byte HeatRockTurnExtension
         {
@@ -708,47 +786,6 @@ namespace Kermalis.PokemonBattleEngine.Data
         }
 
         /// <summary>Creates a new <see cref="PBESettings"/> object where every setting is pre-set to the values used in official games.</summary>
-        public PBESettings()
-        {
-            maxLevel = 100;
-            minLevel = 1;
-            maxPartySize = 6;
-            maxPokemonNameLength = 10;
-            maxTrainerNameLength = 7; // English is 7, other languages are different
-            maxTotalEVs = 510;
-            maxIVs = 31;
-            natureStatBoost = 0.1;
-            maxStatChange = 6;
-            numMoves = 4;
-            ppMultiplier = 5;
-            maxPPUps = 3;
-            critMultiplier = 2.0;
-            confusionMinTurns = 1;
-            confusionMaxTurns = 4;
-            sleepMinTurns = 1;
-            sleepMaxTurns = 3;
-            burnDamageDenominator = 8;
-            poisonDamageDenominator = 8;
-            toxicDamageDenominator = 16;
-            leechSeedDenominator = 8;
-            curseDenominator = 4;
-            leftoversHealDenominator = 16;
-            blackSludgeDamageDenominator = 8;
-            blackSludgeHealDenominator = 16;
-            reflectTurns = 5;
-            lightScreenTurns = 5;
-            lightClayTurnExtension = 3;
-            hailTurns = 5;
-            hailDamageDenominator = 16;
-            icyRockTurnExtension = 3;
-            iceBodyHealDenominator = 16;
-            rainTurns = 5;
-            dampRockTurnExtension = 3;
-            sandstormTurns = 5;
-            sandstormDamageDenominator = 16;
-            smoothRockTurnExtension = 3;
-            sunTurns = 5;
-            heatRockTurnExtension = 3;
-        }
+        public PBESettings() { }
     }
 }

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -861,8 +861,8 @@ namespace Kermalis.PokemonBattleEngine.Data
                 FromBytes(r);
             }
         }
-        /// <summary>Creates a new <see cref="PBESettings"/> object which is deep copied from the specified <see cref="PBESettings"/> object.</summary>
-        /// <param name="other">The <see cref="PBESettings"/> object to deep copy.</param>
+        /// <summary>Creates a new <see cref="PBESettings"/> object which copies the settings from the specified <see cref="PBESettings"/> object. <see cref="IsReadOnly"/> and <see cref="PropertyChanged"/> are not copied.</summary>
+        /// <param name="other">The <see cref="PBESettings"/> object to copy settings from.</param>
         public PBESettings(PBESettings other)
         {
             if (other == null)

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -23,7 +23,7 @@ namespace Kermalis.PokemonBattleEngine.Data
         /// <summary>The default value of <see cref="MaxLevel"/>.</summary>
         public const byte DefaultMaxLevel = 100;
         private byte maxLevel = DefaultMaxLevel;
-        /// <summary>The maximum level a Pokémon can be. Used in stat calculation.</summary>
+        /// <summary>The maximum level a Pokémon can be. Not used in stat/damage calculation.</summary>
         public byte MaxLevel
         {
             get => maxLevel;

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -789,6 +789,21 @@ namespace Kermalis.PokemonBattleEngine.Data
 
         /// <summary>Creates a new <see cref="PBESettings"/> object where every setting is pre-set to the values used in official games.</summary>
         public PBESettings() { }
+        public PBESettings(string code)
+        {
+            if (code == null)
+            {
+                throw new ArgumentNullException(code);
+            }
+            using (var r = new BinaryReader(new MemoryStream(Convert.FromBase64String(code))))
+            {
+                FromBytes(r);
+            }
+        }
+        internal PBESettings(BinaryReader r)
+        {
+            FromBytes(r);
+        }
 
         public override bool Equals(object obj)
         {
@@ -886,17 +901,6 @@ namespace Kermalis.PokemonBattleEngine.Data
         public override string ToString()
         {
             return Convert.ToBase64String(ToBytes().ToArray());
-        }
-        public static PBESettings FromString(string code)
-        {
-            if (code == null)
-            {
-                throw new ArgumentNullException(code);
-            }
-            using (var r = new BinaryReader(new MemoryStream(Convert.FromBase64String(code))))
-            {
-                return FromBytes(r);
-            }
         }
 
         internal List<byte> ToBytes()
@@ -1140,57 +1144,55 @@ namespace Kermalis.PokemonBattleEngine.Data
             bytes.InsertRange(0, BitConverter.GetBytes(numChanged));
             return bytes;
         }
-        internal static PBESettings FromBytes(BinaryReader r)
+        private void FromBytes(BinaryReader r)
         {
-            var settings = new PBESettings();
             ushort numChanged = r.ReadUInt16();
             for (ushort i = 0; i < numChanged; i++)
             {
                 switch ((PBESettingID)r.ReadUInt16())
                 {
-                    case PBESettingID.MaxLevel: settings.MaxLevel = r.ReadByte(); break;
-                    case PBESettingID.MinLevel: settings.MinLevel = r.ReadByte(); break;
-                    case PBESettingID.MaxPartySize: settings.MaxPartySize = r.ReadSByte(); break;
-                    case PBESettingID.MaxPokemonNameLength: settings.MaxPokemonNameLength = r.ReadByte(); break;
-                    case PBESettingID.MaxTrainerNameLength: settings.MaxTrainerNameLength = r.ReadByte(); break;
-                    case PBESettingID.MaxTotalEVs: settings.MaxTotalEVs = r.ReadUInt16(); break;
-                    case PBESettingID.MaxIVs: settings.MaxIVs = r.ReadByte(); break;
-                    case PBESettingID.NatureStatBoost: settings.NatureStatBoost = r.ReadDouble(); break;
-                    case PBESettingID.MaxStatChange: settings.MaxStatChange = r.ReadSByte(); break;
-                    case PBESettingID.NumMoves: settings.NumMoves = r.ReadByte(); break;
-                    case PBESettingID.PPMultiplier: settings.PPMultiplier = r.ReadByte(); break;
-                    case PBESettingID.MaxPPUps: settings.MaxPPUps = r.ReadByte(); break;
-                    case PBESettingID.CritMultiplier: settings.CritMultiplier = r.ReadDouble(); break;
-                    case PBESettingID.ConfusionMaxTurns: settings.ConfusionMaxTurns = r.ReadByte(); break;
-                    case PBESettingID.ConfusionMinTurns: settings.ConfusionMinTurns = r.ReadByte(); break;
-                    case PBESettingID.SleepMaxTurns: settings.SleepMaxTurns = r.ReadByte(); break;
-                    case PBESettingID.SleepMinTurns: settings.SleepMinTurns = r.ReadByte(); break;
-                    case PBESettingID.BurnDamageDenominator: settings.BurnDamageDenominator = r.ReadByte(); break;
-                    case PBESettingID.PoisonDamageDenominator: settings.PoisonDamageDenominator = r.ReadByte(); break;
-                    case PBESettingID.ToxicDamageDenominator: settings.ToxicDamageDenominator = r.ReadByte(); break;
-                    case PBESettingID.LeechSeedDenominator: settings.LeechSeedDenominator = r.ReadByte(); break;
-                    case PBESettingID.CurseDenominator: settings.CurseDenominator = r.ReadByte(); break;
-                    case PBESettingID.LeftoversHealDenominator: settings.LeftoversHealDenominator = r.ReadByte(); break;
-                    case PBESettingID.BlackSludgeDamageDenominator: settings.BlackSludgeDamageDenominator = r.ReadByte(); break;
-                    case PBESettingID.BlackSludgeHealDenominator: settings.BlackSludgeHealDenominator = r.ReadByte(); break;
-                    case PBESettingID.ReflectTurns: settings.ReflectTurns = r.ReadByte(); break;
-                    case PBESettingID.LightScreenTurns: settings.LightScreenTurns = r.ReadByte(); break;
-                    case PBESettingID.LightClayTurnExtension: settings.LightClayTurnExtension = r.ReadByte(); break;
-                    case PBESettingID.HailTurns: settings.HailTurns = r.ReadByte(); break;
-                    case PBESettingID.HailDamageDenominator: settings.HailDamageDenominator = r.ReadByte(); break;
-                    case PBESettingID.IcyRockTurnExtension: settings.IcyRockTurnExtension = r.ReadByte(); break;
-                    case PBESettingID.IceBodyHealDenominator: settings.IceBodyHealDenominator = r.ReadByte(); break;
-                    case PBESettingID.RainTurns: settings.RainTurns = r.ReadByte(); break;
-                    case PBESettingID.DampRockTurnExtension: settings.DampRockTurnExtension = r.ReadByte(); break;
-                    case PBESettingID.SandstormTurns: settings.SandstormTurns = r.ReadByte(); break;
-                    case PBESettingID.SandstormDamageDenominator: settings.SandstormDamageDenominator = r.ReadByte(); break;
-                    case PBESettingID.SmoothRockTurnExtension: settings.SmoothRockTurnExtension = r.ReadByte(); break;
-                    case PBESettingID.SunTurns: settings.SunTurns = r.ReadByte(); break;
-                    case PBESettingID.HeatRockTurnExtension: settings.HeatRockTurnExtension = r.ReadByte(); break;
+                    case PBESettingID.MaxLevel: MaxLevel = r.ReadByte(); break;
+                    case PBESettingID.MinLevel: MinLevel = r.ReadByte(); break;
+                    case PBESettingID.MaxPartySize: MaxPartySize = r.ReadSByte(); break;
+                    case PBESettingID.MaxPokemonNameLength: MaxPokemonNameLength = r.ReadByte(); break;
+                    case PBESettingID.MaxTrainerNameLength: MaxTrainerNameLength = r.ReadByte(); break;
+                    case PBESettingID.MaxTotalEVs: MaxTotalEVs = r.ReadUInt16(); break;
+                    case PBESettingID.MaxIVs: MaxIVs = r.ReadByte(); break;
+                    case PBESettingID.NatureStatBoost: NatureStatBoost = r.ReadDouble(); break;
+                    case PBESettingID.MaxStatChange: MaxStatChange = r.ReadSByte(); break;
+                    case PBESettingID.NumMoves: NumMoves = r.ReadByte(); break;
+                    case PBESettingID.PPMultiplier: PPMultiplier = r.ReadByte(); break;
+                    case PBESettingID.MaxPPUps: MaxPPUps = r.ReadByte(); break;
+                    case PBESettingID.CritMultiplier: CritMultiplier = r.ReadDouble(); break;
+                    case PBESettingID.ConfusionMaxTurns: ConfusionMaxTurns = r.ReadByte(); break;
+                    case PBESettingID.ConfusionMinTurns: ConfusionMinTurns = r.ReadByte(); break;
+                    case PBESettingID.SleepMaxTurns: SleepMaxTurns = r.ReadByte(); break;
+                    case PBESettingID.SleepMinTurns: SleepMinTurns = r.ReadByte(); break;
+                    case PBESettingID.BurnDamageDenominator: BurnDamageDenominator = r.ReadByte(); break;
+                    case PBESettingID.PoisonDamageDenominator: PoisonDamageDenominator = r.ReadByte(); break;
+                    case PBESettingID.ToxicDamageDenominator: ToxicDamageDenominator = r.ReadByte(); break;
+                    case PBESettingID.LeechSeedDenominator: LeechSeedDenominator = r.ReadByte(); break;
+                    case PBESettingID.CurseDenominator: CurseDenominator = r.ReadByte(); break;
+                    case PBESettingID.LeftoversHealDenominator: LeftoversHealDenominator = r.ReadByte(); break;
+                    case PBESettingID.BlackSludgeDamageDenominator: BlackSludgeDamageDenominator = r.ReadByte(); break;
+                    case PBESettingID.BlackSludgeHealDenominator: BlackSludgeHealDenominator = r.ReadByte(); break;
+                    case PBESettingID.ReflectTurns: ReflectTurns = r.ReadByte(); break;
+                    case PBESettingID.LightScreenTurns: LightScreenTurns = r.ReadByte(); break;
+                    case PBESettingID.LightClayTurnExtension: LightClayTurnExtension = r.ReadByte(); break;
+                    case PBESettingID.HailTurns: HailTurns = r.ReadByte(); break;
+                    case PBESettingID.HailDamageDenominator: HailDamageDenominator = r.ReadByte(); break;
+                    case PBESettingID.IcyRockTurnExtension: IcyRockTurnExtension = r.ReadByte(); break;
+                    case PBESettingID.IceBodyHealDenominator: IceBodyHealDenominator = r.ReadByte(); break;
+                    case PBESettingID.RainTurns: RainTurns = r.ReadByte(); break;
+                    case PBESettingID.DampRockTurnExtension: DampRockTurnExtension = r.ReadByte(); break;
+                    case PBESettingID.SandstormTurns: SandstormTurns = r.ReadByte(); break;
+                    case PBESettingID.SandstormDamageDenominator: SandstormDamageDenominator = r.ReadByte(); break;
+                    case PBESettingID.SmoothRockTurnExtension: SmoothRockTurnExtension = r.ReadByte(); break;
+                    case PBESettingID.SunTurns: SunTurns = r.ReadByte(); break;
+                    case PBESettingID.HeatRockTurnExtension: HeatRockTurnExtension = r.ReadByte(); break;
                     default: throw new InvalidDataException();
                 }
             }
-            return settings;
         }
     }
 }

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -807,7 +807,20 @@ namespace Kermalis.PokemonBattleEngine.Data
 
         public override bool Equals(object obj)
         {
-            if (obj is PBESettings other)
+            if (obj is string str)
+            {
+                PBESettings ps;
+                try
+                {
+                    ps = new PBESettings(str);
+                }
+                catch
+                {
+                    return false;
+                }
+                return ps.Equals(this);
+            }
+            else if (obj is PBESettings other)
             {
                 return other.maxLevel.Equals(maxLevel)
                     && other.minLevel.Equals(minLevel)

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace Kermalis.PokemonBattleEngine.Data
 {
-    // TODO: .Equals, ability to make read-only
+    // TODO: Ability to make read-only
     /// <summary>The various engine settings.</summary>
     public sealed class PBESettings : INotifyPropertyChanged
     {
@@ -789,6 +789,56 @@ namespace Kermalis.PokemonBattleEngine.Data
 
         /// <summary>Creates a new <see cref="PBESettings"/> object where every setting is pre-set to the values used in official games.</summary>
         public PBESettings() { }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PBESettings other)
+            {
+                return other.maxLevel.Equals(maxLevel)
+                    && other.minLevel.Equals(minLevel)
+                    && other.maxPartySize.Equals(maxPartySize)
+                    && other.maxPokemonNameLength.Equals(maxPokemonNameLength)
+                    && other.maxTrainerNameLength.Equals(maxTrainerNameLength)
+                    && other.maxTotalEVs.Equals(maxTotalEVs)
+                    && other.maxIVs.Equals(maxIVs)
+                    && other.natureStatBoost.Equals(natureStatBoost)
+                    && other.maxStatChange.Equals(maxStatChange)
+                    && other.numMoves.Equals(numMoves)
+                    && other.ppMultiplier.Equals(ppMultiplier)
+                    && other.maxPPUps.Equals(maxPPUps)
+                    && other.critMultiplier.Equals(critMultiplier)
+                    && other.confusionMaxTurns.Equals(confusionMaxTurns)
+                    && other.confusionMinTurns.Equals(confusionMinTurns)
+                    && other.sleepMaxTurns.Equals(sleepMaxTurns)
+                    && other.sleepMinTurns.Equals(sleepMinTurns)
+                    && other.burnDamageDenominator.Equals(burnDamageDenominator)
+                    && other.poisonDamageDenominator.Equals(poisonDamageDenominator)
+                    && other.toxicDamageDenominator.Equals(toxicDamageDenominator)
+                    && other.leechSeedDenominator.Equals(leechSeedDenominator)
+                    && other.curseDenominator.Equals(curseDenominator)
+                    && other.leftoversHealDenominator.Equals(leftoversHealDenominator)
+                    && other.blackSludgeDamageDenominator.Equals(blackSludgeDamageDenominator)
+                    && other.blackSludgeHealDenominator.Equals(blackSludgeHealDenominator)
+                    && other.reflectTurns.Equals(reflectTurns)
+                    && other.lightScreenTurns.Equals(lightScreenTurns)
+                    && other.lightClayTurnExtension.Equals(lightClayTurnExtension)
+                    && other.hailTurns.Equals(hailTurns)
+                    && other.hailDamageDenominator.Equals(hailDamageDenominator)
+                    && other.icyRockTurnExtension.Equals(icyRockTurnExtension)
+                    && other.iceBodyHealDenominator.Equals(iceBodyHealDenominator)
+                    && other.rainTurns.Equals(rainTurns)
+                    && other.dampRockTurnExtension.Equals(dampRockTurnExtension)
+                    && other.sandstormTurns.Equals(sandstormTurns)
+                    && other.sandstormDamageDenominator.Equals(sandstormDamageDenominator)
+                    && other.smoothRockTurnExtension.Equals(smoothRockTurnExtension)
+                    && other.sunTurns.Equals(sunTurns)
+                    && other.heatRockTurnExtension.Equals(heatRockTurnExtension);
+            }
+            else
+            {
+                return false;
+            }
+        }
 
         private enum PBESettingID : ushort
         {

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -901,7 +901,7 @@ namespace Kermalis.PokemonBattleEngine.Data
                 bytes.AddRange(BitConverter.GetBytes(natureStatBoost));
                 numChanged++;
             }
-            if (maxStatChange != MaxStatChange)
+            if (maxStatChange != DefaultMaxStatChange)
             {
                 bytes.AddRange(BitConverter.GetBytes((ushort)PBESettingID.MaxStatChange));
                 bytes.Add((byte)maxStatChange);

--- a/PokemonBattleEngine/Data/Settings.cs
+++ b/PokemonBattleEngine/Data/Settings.cs
@@ -6,7 +6,6 @@ using System.IO;
 
 namespace Kermalis.PokemonBattleEngine.Data
 {
-    // TODO: Ability to make read-only
     /// <summary>The various engine settings.</summary>
     public sealed class PBESettings : INotifyPropertyChanged
     {
@@ -17,8 +16,29 @@ namespace Kermalis.PokemonBattleEngine.Data
         /// <summary>Fires whenever a property changes.</summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
+        private bool isReadOnly;
+        /// <summary>Gets a value that indicates whether this <see cref="PBESettings"/> object is read-only.</summary>
+        public bool IsReadOnly
+        {
+            get => isReadOnly;
+            private set
+            {
+                if (isReadOnly != value)
+                {
+                    isReadOnly = value;
+                    OnPropertyChanged(nameof(IsReadOnly));
+                }
+            }
+        }
+
         /// <summary>The default settings used in official games.</summary>
-        public static PBESettings DefaultSettings { get; } = new PBESettings();
+        public static PBESettings DefaultSettings { get; }
+
+        static PBESettings()
+        {
+            DefaultSettings = new PBESettings();
+            DefaultSettings.MakeReadOnly();
+        }
 
         /// <summary>The default value of <see cref="MaxLevel"/>.</summary>
         public const byte DefaultMaxLevel = 100;
@@ -29,6 +49,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => maxLevel;
             set
             {
+                ReadOnlyCheck();
                 if (maxLevel != value)
                 {
                     if (value < minLevel)
@@ -49,6 +70,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => minLevel;
             set
             {
+                ReadOnlyCheck();
                 if (minLevel != value)
                 {
                     if (value < 1 || value > maxLevel)
@@ -69,6 +91,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => maxPartySize;
             set
             {
+                ReadOnlyCheck();
                 if (maxPartySize != value)
                 {
                     if (value < 1)
@@ -89,6 +112,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => maxPokemonNameLength;
             set
             {
+                ReadOnlyCheck();
                 if (maxPokemonNameLength != value)
                 {
                     if (value < 1)
@@ -104,12 +128,13 @@ namespace Kermalis.PokemonBattleEngine.Data
         public const byte DefaultMaxTrainerNameLength = 7;
         private byte maxTrainerNameLength = DefaultMaxTrainerNameLength;
         /// <summary>The maximum amount of characters a trainer's name can have.</summary>
-        [Obsolete("Currently not used anywhere")]
+        [Obsolete("Currently not used anywhere.")]
         public byte MaxTrainerNameLength
         {
             get => maxTrainerNameLength;
             set
             {
+                ReadOnlyCheck();
                 if (maxTrainerNameLength != value)
                 {
                     if (value < 1)
@@ -131,6 +156,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             set
             {
                 const int max = byte.MaxValue * 6;
+                ReadOnlyCheck();
                 if (maxTotalEVs != value)
                 {
                     if (value > max)
@@ -151,6 +177,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => maxIVs;
             set
             {
+                ReadOnlyCheck();
                 if (maxIVs != value)
                 {
                     maxIVs = value;
@@ -167,6 +194,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => natureStatBoost;
             set
             {
+                ReadOnlyCheck();
                 if (natureStatBoost != value)
                 {
                     if (value < 0)
@@ -187,6 +215,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => maxStatChange;
             set
             {
+                ReadOnlyCheck();
                 if (maxStatChange != value)
                 {
                     maxStatChange = value;
@@ -203,6 +232,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => numMoves;
             set
             {
+                ReadOnlyCheck();
                 if (numMoves != value)
                 {
                     if (value < 1)
@@ -227,6 +257,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => ppMultiplier;
             set
             {
+                ReadOnlyCheck();
                 if (ppMultiplier != value)
                 {
                     if (value < 1)
@@ -247,6 +278,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => maxPPUps;
             set
             {
+                ReadOnlyCheck();
                 if (maxPPUps != value)
                 {
                     maxPPUps = value;
@@ -263,6 +295,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => critMultiplier;
             set
             {
+                ReadOnlyCheck();
                 if (critMultiplier != value)
                 {
                     critMultiplier = value;
@@ -279,6 +312,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => confusionMaxTurns;
             set
             {
+                ReadOnlyCheck();
                 if (confusionMaxTurns != value)
                 {
                     if (value < confusionMinTurns)
@@ -299,6 +333,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => confusionMinTurns;
             set
             {
+                ReadOnlyCheck();
                 if (confusionMinTurns != value)
                 {
                     if (value > confusionMaxTurns)
@@ -319,6 +354,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => sleepMaxTurns;
             set
             {
+                ReadOnlyCheck();
                 if (sleepMaxTurns != value)
                 {
                     if (value < sleepMinTurns)
@@ -339,6 +375,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => sleepMinTurns;
             set
             {
+                ReadOnlyCheck();
                 if (sleepMinTurns != value)
                 {
                     if (value > sleepMaxTurns)
@@ -359,6 +396,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => burnDamageDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (burnDamageDenominator != value)
                 {
                     if (value < 1)
@@ -379,6 +417,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => poisonDamageDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (poisonDamageDenominator != value)
                 {
                     if (value < 1)
@@ -399,6 +438,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => toxicDamageDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (toxicDamageDenominator != value)
                 {
                     if (value < 1)
@@ -419,6 +459,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => leechSeedDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (leechSeedDenominator != value)
                 {
                     if (value < 1)
@@ -439,6 +480,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => curseDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (curseDenominator != value)
                 {
                     if (value < 1)
@@ -459,6 +501,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => leftoversHealDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (leftoversHealDenominator != value)
                 {
                     if (value < 1)
@@ -479,6 +522,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => blackSludgeDamageDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (blackSludgeDamageDenominator != value)
                 {
                     if (value < 1)
@@ -499,6 +543,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => blackSludgeHealDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (blackSludgeHealDenominator != value)
                 {
                     if (value < 1)
@@ -519,6 +564,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => reflectTurns;
             set
             {
+                ReadOnlyCheck();
                 if (reflectTurns != value)
                 {
                     if (value < 1)
@@ -539,6 +585,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => lightScreenTurns;
             set
             {
+                ReadOnlyCheck();
                 if (lightScreenTurns != value)
                 {
                     if (value < 1)
@@ -559,6 +606,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => lightClayTurnExtension;
             set
             {
+                ReadOnlyCheck();
                 if (lightClayTurnExtension != value)
                 {
                     lightClayTurnExtension = value;
@@ -575,6 +623,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => hailTurns;
             set
             {
+                ReadOnlyCheck();
                 if (hailTurns != value)
                 {
                     if (value == 0 && icyRockTurnExtension != 0)
@@ -595,6 +644,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => hailDamageDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (hailDamageDenominator != value)
                 {
                     if (value < 1)
@@ -615,6 +665,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => icyRockTurnExtension;
             set
             {
+                ReadOnlyCheck();
                 if (icyRockTurnExtension != value)
                 {
                     if (value != 0 && hailTurns == 0)
@@ -635,6 +686,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => iceBodyHealDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (iceBodyHealDenominator != value)
                 {
                     if (value < 1)
@@ -655,6 +707,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => rainTurns;
             set
             {
+                ReadOnlyCheck();
                 if (rainTurns != value)
                 {
                     if (value == 0 && dampRockTurnExtension != 0)
@@ -675,6 +728,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => dampRockTurnExtension;
             set
             {
+                ReadOnlyCheck();
                 if (dampRockTurnExtension != value)
                 {
                     if (value != 0 && rainTurns == 0)
@@ -695,6 +749,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => sandstormTurns;
             set
             {
+                ReadOnlyCheck();
                 if (sandstormTurns != value)
                 {
                     if (value == 0 && smoothRockTurnExtension != 0)
@@ -715,6 +770,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => sandstormDamageDenominator;
             set
             {
+                ReadOnlyCheck();
                 if (sandstormDamageDenominator != value)
                 {
                     if (value < 1)
@@ -735,6 +791,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => smoothRockTurnExtension;
             set
             {
+                ReadOnlyCheck();
                 if (smoothRockTurnExtension != value)
                 {
                     if (value != 0 && sandstormTurns == 0)
@@ -755,6 +812,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => sunTurns;
             set
             {
+                ReadOnlyCheck();
                 if (sunTurns != value)
                 {
                     if (value == 0 && heatRockTurnExtension != 0)
@@ -775,6 +833,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             get => heatRockTurnExtension;
             set
             {
+                ReadOnlyCheck();
                 if (heatRockTurnExtension != value)
                 {
                     if (value != 0 && sunTurns == 0)
@@ -789,6 +848,8 @@ namespace Kermalis.PokemonBattleEngine.Data
 
         /// <summary>Creates a new <see cref="PBESettings"/> object where every setting is pre-set to the values used in official games.</summary>
         public PBESettings() { }
+        /// <summary>Creates a new <see cref="PBESettings"/> object with the specified code <see cref="string"/>.</summary>
+        /// <param name="code">The code <see cref="string"/> to use.</param>
         public PBESettings(string code)
         {
             if (code == null)
@@ -800,11 +861,77 @@ namespace Kermalis.PokemonBattleEngine.Data
                 FromBytes(r);
             }
         }
+        /// <summary>Creates a new <see cref="PBESettings"/> object which is deep copied from the specified <see cref="PBESettings"/> object.</summary>
+        /// <param name="other">The <see cref="PBESettings"/> object to deep copy.</param>
+        public PBESettings(PBESettings other)
+        {
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+            MaxLevel = other.maxLevel;
+            MinLevel = other.minLevel;
+            MaxPartySize = other.maxPartySize;
+            MaxPokemonNameLength = other.maxPokemonNameLength;
+            MaxTrainerNameLength = other.maxTrainerNameLength;
+            MaxTotalEVs = other.maxTotalEVs;
+            MaxIVs = other.maxIVs;
+            NatureStatBoost = other.natureStatBoost;
+            MaxStatChange = other.maxStatChange;
+            NumMoves = other.numMoves;
+            PPMultiplier = other.ppMultiplier;
+            MaxPPUps = other.maxPPUps;
+            CritMultiplier = other.critMultiplier;
+            ConfusionMaxTurns = other.confusionMaxTurns;
+            ConfusionMinTurns = other.confusionMinTurns;
+            SleepMaxTurns = other.sleepMaxTurns;
+            SleepMinTurns = other.sleepMinTurns;
+            BurnDamageDenominator = other.burnDamageDenominator;
+            PoisonDamageDenominator = other.poisonDamageDenominator;
+            ToxicDamageDenominator = other.toxicDamageDenominator;
+            LeechSeedDenominator = other.leechSeedDenominator;
+            CurseDenominator = other.curseDenominator;
+            LeftoversHealDenominator = other.leftoversHealDenominator;
+            BlackSludgeDamageDenominator = other.blackSludgeDamageDenominator;
+            BlackSludgeHealDenominator = other.blackSludgeHealDenominator;
+            ReflectTurns = other.reflectTurns;
+            LightScreenTurns = other.lightScreenTurns;
+            LightClayTurnExtension = other.lightClayTurnExtension;
+            HailTurns = other.hailTurns;
+            HailDamageDenominator = other.hailDamageDenominator;
+            IcyRockTurnExtension = other.icyRockTurnExtension;
+            IceBodyHealDenominator = other.iceBodyHealDenominator;
+            RainTurns = other.rainTurns;
+            DampRockTurnExtension = other.dampRockTurnExtension;
+            SandstormTurns = other.sandstormTurns;
+            SandstormDamageDenominator = other.sandstormDamageDenominator;
+            SmoothRockTurnExtension = other.smoothRockTurnExtension;
+            SunTurns = other.sunTurns;
+            HeatRockTurnExtension = other.heatRockTurnExtension;
+        }
         internal PBESettings(BinaryReader r)
         {
             FromBytes(r);
         }
 
+        private void ReadOnlyCheck()
+        {
+            if (isReadOnly)
+            {
+                throw new InvalidOperationException($"This {nameof(PBESettings)} is marked as read-only.");
+            }
+        }
+        /// <summary>Marks this <see cref="PBESettings"/> object as read-only.</summary>
+        public void MakeReadOnly()
+        {
+            if (!isReadOnly)
+            {
+                IsReadOnly = true;
+            }
+        }
+
+        /// <summary>Returns a value indicating whether a code <see cref="string"/> or another <see cref="PBESettings"/> object represent the same settings as this <see cref="PBESettings"/> object.</summary>
+        /// <param name="obj">The code <see cref="string"/> or the <see cref="PBESettings"/> object to check for equality.</param>
         public override bool Equals(object obj)
         {
             if (obj is string str)
@@ -911,6 +1038,7 @@ namespace Kermalis.PokemonBattleEngine.Data
             HeatRockTurnExtension
         }
 
+        /// <summary>Converts this <see cref="PBESettings"/> object into a unique code <see cref="string"/>.</summary>
         public override string ToString()
         {
             return Convert.ToBase64String(ToBytes().ToArray());

--- a/PokemonBattleEngine/Data/TeamShell.cs
+++ b/PokemonBattleEngine/Data/TeamShell.cs
@@ -198,14 +198,13 @@ namespace Kermalis.PokemonBattleEngine.Data
 
         private void OnSettingsChanged(object sender, PropertyChangedEventArgs e)
         {
-            var settings = (PBESettings)sender;
             switch (e.PropertyName)
             {
-                case nameof(settings.MaxPartySize):
+                case nameof(Settings.MaxPartySize):
                 {
-                    if (list.Count > settings.MaxPartySize)
+                    if (list.Count > Settings.MaxPartySize)
                     {
-                        int numToRemove = list.Count - settings.MaxPartySize;
+                        int numToRemove = list.Count - Settings.MaxPartySize;
                         var changedItems = new PBEPokemonShell[numToRemove];
                         for (int i = 0; i < numToRemove; i++)
                         {

--- a/PokemonBattleEngine/Data/TeamShell.cs
+++ b/PokemonBattleEngine/Data/TeamShell.cs
@@ -1,0 +1,212 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+
+namespace Kermalis.PokemonBattleEngine.Data
+{
+    public sealed class PBETeamShell : IEnumerable<PBEPokemonShell>, INotifyCollectionChanged, INotifyPropertyChanged
+    {
+        private void FireEvents(NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(Count));
+            OnPropertyChanged("Item[]");
+            OnCollectionChanged(e);
+        }
+        private void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
+            CollectionChanged?.Invoke(this, e);
+        }
+        private void OnPropertyChanged(string property)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
+        }
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private readonly List<PBEPokemonShell> list;
+        public int Count => list.Count;
+        public PBEPokemonShell this[int index] => list[index];
+
+        public PBESettings Settings { get; }
+
+        internal PBETeamShell(BinaryReader r)
+        {
+            Settings = new PBESettings(r);
+            list = new List<PBEPokemonShell>(Settings.MaxPartySize);
+            sbyte count = r.ReadSByte();
+            if (count < 1 || count > Settings.MaxPartySize)
+            {
+                throw new InvalidDataException();
+            }
+            for (int i = 0; i < count; i++)
+            {
+                list.Add(new PBEPokemonShell(r, this));
+            }
+        }
+        public PBETeamShell(string path)
+        {
+            var json = JObject.Parse(File.ReadAllText(path));
+            Settings = new PBESettings(json[nameof(Settings)].Value<string>());
+            var partyObj = (JArray)json["Party"];
+            if (partyObj.Count < 1 || partyObj.Count > Settings.MaxPartySize)
+            {
+                throw new InvalidDataException("File has an invalid party size for the settings provided.");
+            }
+            list = new List<PBEPokemonShell>(Settings.MaxPartySize);
+            for (int i = 0; i < partyObj.Count; i++)
+            {
+                list.Add(new PBEPokemonShell(partyObj[i], this));
+            }
+        }
+        public PBETeamShell(PBESettings settings, int numPkmnToGenerate, bool setToMaxLevel)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (numPkmnToGenerate < 1 || numPkmnToGenerate > settings.MaxPartySize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(numPkmnToGenerate));
+            }
+            Settings = settings;
+            list = new List<PBEPokemonShell>(settings.MaxPartySize);
+            for (int i = 0; i < numPkmnToGenerate; i++)
+            {
+                AddOne(false, PBEUtils.RandomSpecies(), setToMaxLevel ? settings.MaxLevel : PBEUtils.RandomLevel(settings));
+            }
+        }
+
+        private void AddOne(bool fireEvent)
+        {
+            AddOne(fireEvent, PBEUtils.RandomSpecies(), PBEUtils.RandomLevel(Settings));
+        }
+        private void AddOne(bool fireEvent, PBESpecies species, byte level)
+        {
+            var item = new PBEPokemonShell(species, level, this);
+            int index = list.Count;
+            list.Insert(index, item);
+            if (fireEvent)
+            {
+                FireEvents(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+            }
+        }
+
+        public void Add()
+        {
+            Add(PBEUtils.RandomSpecies(), PBEUtils.RandomLevel(Settings));
+        }
+        public void Add(PBESpecies species, byte level)
+        {
+            if (list.Count < Settings.MaxPartySize)
+            {
+                AddOne(true, species, level);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Party size cannot exceed \"{nameof(Settings.MaxPartySize)}\" ({Settings.MaxPartySize}).");
+            }
+        }
+        public void Clear()
+        {
+            list.Clear();
+            AddOne(false);
+            FireEvents(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+        public bool Remove(PBEPokemonShell item)
+        {
+            int index = list.IndexOf(item);
+            bool b = index != -1;
+            if (b)
+            {
+                list.RemoveAt(index);
+                NotifyCollectionChangedEventArgs e;
+                if (list.Count == 0)
+                {
+                    AddOne(false);
+                    e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+                }
+                else
+                {
+                    e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index);
+                }
+                FireEvents(e);
+            }
+            return b;
+        }
+        public void RemoveAt(int index)
+        {
+            if (index >= list.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+            else
+            {
+                PBEPokemonShell item = list[index];
+                list.RemoveAt(index);
+                NotifyCollectionChangedEventArgs e;
+                if (list.Count == 0)
+                {
+                    AddOne(false);
+                    e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+                }
+                else
+                {
+                    e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index);
+                }
+                FireEvents(e);
+            }
+        }
+
+        public bool Contains(PBEPokemonShell item)
+        {
+            return list.IndexOf(item) != -1;
+        }
+        public int IndexOf(PBEPokemonShell item)
+        {
+            return list.IndexOf(item);
+        }
+
+        public IEnumerator<PBEPokemonShell> GetEnumerator()
+        {
+            return list.GetEnumerator();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return list.GetEnumerator();
+        }
+
+        internal List<byte> ToBytes()
+        {
+            var bytes = new List<byte>();
+            bytes.AddRange(Settings.ToBytes());
+            bytes.Add((byte)list.Count);
+            for (int i = 0; i < list.Count; i++)
+            {
+                bytes.AddRange(list[i].ToBytes());
+            }
+            return bytes;
+        }
+        public void ToJsonFile(string path)
+        {
+            using (var w = new JsonTextWriter(File.CreateText(path)) { Formatting = Formatting.Indented })
+            {
+                w.WriteStartObject();
+                w.WritePropertyName(nameof(Settings));
+                w.WriteValue(Settings.ToString());
+                w.WritePropertyName("Party");
+                w.WriteStartArray();
+                for (int i = 0; i < list.Count; i++)
+                {
+                    list[i].ToJson(w);
+                }
+                w.WriteEndArray();
+                w.WriteEndObject();
+            }
+        }
+    }
+}

--- a/PokemonBattleEngine/Packets/PartyResponsePacket.cs
+++ b/PokemonBattleEngine/Packets/PartyResponsePacket.cs
@@ -3,7 +3,6 @@ using Kermalis.PokemonBattleEngine.Battle;
 using Kermalis.PokemonBattleEngine.Data;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 
@@ -14,14 +13,13 @@ namespace Kermalis.PokemonBattleEngine.Packets
         public const short Code = 0x04;
         public IEnumerable<byte> Buffer { get; }
 
-        public ReadOnlyCollection<PBEPokemonShell> Party { get; }
+        public PBETeamShell TeamShell { get; }
 
-        public PBEPartyResponsePacket(IEnumerable<PBEPokemonShell> party)
+        public PBEPartyResponsePacket(PBETeamShell teamShell)
         {
             var bytes = new List<byte>();
             bytes.AddRange(BitConverter.GetBytes(Code));
-            bytes.Add((byte)(Party = party.ToList().AsReadOnly()).Count);
-            bytes.AddRange(Party.SelectMany(p => p.ToBytes()));
+            bytes.AddRange((TeamShell = teamShell).ToBytes());
             Buffer = BitConverter.GetBytes((short)bytes.Count).Concat(bytes);
         }
         public PBEPartyResponsePacket(byte[] buffer, PBEBattle battle)
@@ -29,13 +27,8 @@ namespace Kermalis.PokemonBattleEngine.Packets
             Buffer = buffer;
             using (var r = new BinaryReader(new MemoryStream(buffer)))
             {
-                r.ReadInt16(); // Skip Code
-                var party = new PBEPokemonShell[r.ReadSByte()];
-                for (int i = 0; i < party.Length; i++)
-                {
-                    party[i] = PBEPokemonShell.FromBytes(r, battle.Settings); // What happens if an exception occurs? Similar question to https://github.com/Kermalis/PokemonBattleEngine/issues/167
-                }
-                Party = Array.AsReadOnly(party);
+                r.ReadInt16(); // Skip Code                               
+                TeamShell = new PBETeamShell(r); // What happens if an exception occurs? Similar question to https://github.com/Kermalis/PokemonBattleEngine/issues/167
             }
         }
 

--- a/PokemonBattleEngine/Packets/SetPartyPacket.cs
+++ b/PokemonBattleEngine/Packets/SetPartyPacket.cs
@@ -35,7 +35,7 @@ namespace Kermalis.PokemonBattleEngine.Packets
                 var party = new PBEPokemon[r.ReadByte()];
                 for (int i = 0; i < party.Length; i++)
                 {
-                    party[i] = PBEPokemon.FromBytes(r, Team);
+                    party[i] = new PBEPokemon(r, Team);
                 }
                 Party = Array.AsReadOnly(party);
             }

--- a/PokemonBattleEngine/Packets/_PkmnSwitchInPacket.cs
+++ b/PokemonBattleEngine/Packets/_PkmnSwitchInPacket.cs
@@ -44,8 +44,23 @@ namespace Kermalis.PokemonBattleEngine.Packets
                 Status1 = status1;
                 FieldPosition = fieldPosition;
             }
+            internal PBESwitchInInfo(BinaryReader r)
+            {
+                PokemonId = r.ReadByte();
+                DisguisedAsId = r.ReadByte();
+                Species = (PBESpecies)r.ReadUInt32();
+                Nickname = PBEUtils.StringFromBytes(r);
+                Level = r.ReadByte();
+                Shiny = r.ReadBoolean();
+                Gender = (PBEGender)r.ReadByte();
+                HP = r.ReadUInt16();
+                MaxHP = r.ReadUInt16();
+                HPPercentage = r.ReadDouble();
+                Status1 = (PBEStatus1)r.ReadByte();
+                FieldPosition = (PBEFieldPosition)r.ReadByte();
+            }
 
-            internal byte[] ToBytes()
+            internal List<byte> ToBytes()
             {
                 var bytes = new List<byte>();
                 bytes.Add(PokemonId);
@@ -60,11 +75,7 @@ namespace Kermalis.PokemonBattleEngine.Packets
                 bytes.AddRange(BitConverter.GetBytes(HPPercentage));
                 bytes.Add((byte)Status1);
                 bytes.Add((byte)FieldPosition);
-                return bytes.ToArray();
-            }
-            internal static PBESwitchInInfo FromBytes(BinaryReader r)
-            {
-                return new PBESwitchInInfo(r.ReadByte(), r.ReadByte(), (PBESpecies)r.ReadUInt32(), PBEUtils.StringFromBytes(r), r.ReadByte(), r.ReadBoolean(), (PBEGender)r.ReadByte(), r.ReadUInt16(), r.ReadUInt16(), r.ReadDouble(), (PBEStatus1)r.ReadByte(), (PBEFieldPosition)r.ReadByte());
+                return bytes;
             }
         }
 
@@ -94,7 +105,7 @@ namespace Kermalis.PokemonBattleEngine.Packets
                 var switches = new PBESwitchInInfo[r.ReadByte()];
                 for (int i = 0; i < switches.Length; i++)
                 {
-                    switches[i] = PBESwitchInInfo.FromBytes(r);
+                    switches[i] = new PBESwitchInInfo(r);
                 }
                 SwitchIns = Array.AsReadOnly(switches);
                 Forced = r.ReadBoolean();

--- a/PokemonBattleEngine/Utils.cs
+++ b/PokemonBattleEngine/Utils.cs
@@ -247,13 +247,13 @@ namespace Kermalis.PokemonBattleEngine
             return fileName;
         }
 
-        internal static byte[] StringToBytes(string str)
+        internal static List<byte> StringToBytes(string str)
         {
             var bytes = new List<byte>();
             byte[] nameBytes = Encoding.Unicode.GetBytes(str);
             bytes.Add((byte)nameBytes.Length);
             bytes.AddRange(nameBytes);
-            return bytes.ToArray();
+            return bytes;
         }
         internal static string StringFromBytes(BinaryReader r)
         {

--- a/PokemonBattleEngine/Utils.cs
+++ b/PokemonBattleEngine/Utils.cs
@@ -27,14 +27,20 @@ namespace Kermalis.PokemonBattleEngine
         }
         /// <summary>Creates a connection to PokemonBattleEngine.db. This must be called only once; before the database is used.</summary>
         /// <param name="databasePath">The path of the folder containing PokemonBattleEngine.db.</param>
-        /// <exception cref="InvalidOperationException">Thrown when <paramref name="databasePath"/> is null, contains only whitespace characters, or contains one or more of the invalid characters defined in <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="databasePath"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="databasePath"/> contains one or more of the invalid characters defined in <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when a database connection has already been created.</exception>
         public static void CreateDatabaseConnection(string databasePath)
         {
             if (databaseConnection != null)
             {
                 throw new InvalidOperationException("Database connection was already created.");
             }
-            else if (string.IsNullOrWhiteSpace(databasePath) || databasePath.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+            else if (databasePath == null)
+            {
+                throw new ArgumentNullException(nameof(databasePath));
+            }
+            else if (databasePath.IndexOfAny(Path.GetInvalidPathChars()) != -1)
             {
                 throw new ArgumentOutOfRangeException(nameof(databasePath));
             }

--- a/PokemonBattleEngine/Utils.cs
+++ b/PokemonBattleEngine/Utils.cs
@@ -51,18 +51,6 @@ namespace Kermalis.PokemonBattleEngine
         /// I decided to switch from <see cref="Random"/> to <see cref="RNGCryptoServiceProvider"/> because I did not need the better speed or the seeded constructor and because <see cref="RNGCryptoServiceProvider"/> provides better random outputs.
         /// </summary>
         private static readonly RNGCryptoServiceProvider rand = new RNGCryptoServiceProvider();
-        /// <summary>Creates an array of <see cref="PBEPokemonShell"/>s each with completely random properties. The amount to create is <see cref="PBESettings.MaxPartySize"/>.</summary>
-        /// <param name="settings">The settings to use.</param>
-        /// <param name="setToMaxLevel">True if <see cref="PBEPokemonShell.Level"/> will be set to <see cref="PBESettings.MaxLevel"/>.</param>
-        public static PBEPokemonShell[] CreateCompletelyRandomTeam(PBESettings settings, bool setToMaxLevel)
-        {
-            var team = new PBEPokemonShell[settings.MaxPartySize];
-            for (int i = 0; i < settings.MaxPartySize; i++)
-            {
-                team[i] = new PBEPokemonShell(RandomSpecies(), setToMaxLevel ? settings.MaxLevel : (byte)RandomInt(settings.MinLevel, settings.MaxLevel), settings);
-            }
-            return team;
-        }
         internal static bool RandomBool()
         {
             return RandomInt(0, 1) == 1;
@@ -111,6 +99,14 @@ namespace Kermalis.PokemonBattleEngine
             }
             double d = scale / (double)uint.MaxValue;
             return (int)(minValue + (((long)maxValue + 1 - minValue) * d)); // Remove "+ 1" for exclusive maxValue
+        }
+        public static byte RandomLevel(PBESettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            return (byte)RandomInt(settings.MinLevel, settings.MaxLevel);
         }
         /// <summary>Returns a random shiny value.</summary>
         public static bool RandomShiny()

--- a/PokemonBattleEngineClient/BattleClient.cs
+++ b/PokemonBattleEngineClient/BattleClient.cs
@@ -34,18 +34,18 @@ namespace Kermalis.PokemonBattleEngineClient
         public readonly ClientMode Mode;
         public int BattleId = int.MaxValue;
         public bool ShowRawValues0, ShowRawValues1;
-        private readonly IEnumerable<PBEPokemonShell> partyShells;
+        private readonly PBETeamShell teamShell;
 
-        public BattleClient(string host, int port, PBEBattleFormat battleFormat, PBESettings settings, IEnumerable<PBEPokemonShell> party)
+        public BattleClient(string host, int port, PBEBattleFormat battleFormat, PBETeamShell teamShell)
         {
             Configuration.Host = host;
             Configuration.Port = port;
             Configuration.BufferSize = 1024;
 
             Mode = ClientMode.Online;
-            Battle = new PBEBattle(battleFormat, settings);
+            Battle = new PBEBattle(battleFormat, teamShell.Settings);
             packetProcessor = new PBEPacketProcessor(Battle);
-            partyShells = party;
+            this.teamShell = teamShell;
 
             packetTimer.Elapsed += PacketTimer_Elapsed;
             packetTimer.Start();
@@ -101,7 +101,7 @@ namespace Kermalis.PokemonBattleEngineClient
                 }
                 case PBEPartyRequestPacket _:
                 {
-                    Send(new PBEPartyResponsePacket(partyShells));
+                    Send(new PBEPartyResponsePacket(teamShell));
                     break;
                 }
                 case PBESetPartyPacket spp:

--- a/PokemonBattleEngineClient/MainView.xaml.cs
+++ b/PokemonBattleEngineClient/MainView.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
-using Kermalis.PokemonBattleEngine;
 using Kermalis.PokemonBattleEngine.Battle;
 using Kermalis.PokemonBattleEngine.Data;
 using Kermalis.PokemonBattleEngineClient.Views;
@@ -59,7 +58,7 @@ namespace Kermalis.PokemonBattleEngineClient
         {
             connect.IsEnabled = false;
             ConnectText = "Connecting...";
-            var client = new BattleClient(ip.Text, (int)port.Value, PBEBattleFormat.Double, teamBuilder.Settings, teamBuilder.Team.Party);
+            var client = new BattleClient(ip.Text, (int)port.Value, PBEBattleFormat.Double, teamBuilder.Team.Shell);
             new Thread(() =>
             {
                 client.Connect();
@@ -84,10 +83,12 @@ namespace Kermalis.PokemonBattleEngineClient
         private void SinglePlayer()
         {
             PBESettings settings = PBESettings.DefaultSettings;
-            PBEPokemonShell[] team0Party, team1Party;
-            team0Party = PBEUtils.CreateCompletelyRandomTeam(settings, true);
-            team1Party = PBEUtils.CreateCompletelyRandomTeam(settings, true);
-            var battle = new PBEBattle(PBEBattleFormat.Double, settings, team0Party, team1Party);
+            PBETeamShell team0Shell, team1Shell;
+            // Completely Randomized Pokémon
+            team0Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
+            team1Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
+
+            var battle = new PBEBattle(PBEBattleFormat.Double, team0Shell, team1Shell);
             battle.Teams[0].TrainerName = "May";
             battle.Teams[1].TrainerName = "Champion Steven";
             Add(new BattleClient(battle, BattleClient.ClientMode.SinglePlayer));

--- a/PokemonBattleEngineClient/MainView.xaml.cs
+++ b/PokemonBattleEngineClient/MainView.xaml.cs
@@ -88,9 +88,7 @@ namespace Kermalis.PokemonBattleEngineClient
             team0Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
             team1Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
 
-            var battle = new PBEBattle(PBEBattleFormat.Double, team0Shell, team1Shell);
-            battle.Teams[0].TrainerName = "May";
-            battle.Teams[1].TrainerName = "Champion Steven";
+            var battle = new PBEBattle(PBEBattleFormat.Double, team0Shell, "May", team1Shell, "Champion Steven");
             Add(new BattleClient(battle, BattleClient.ClientMode.SinglePlayer));
             new Thread(battle.Begin) { Name = "Battle Thread" }.Start();
         }

--- a/PokemonBattleEngineClient/Models/TeamInfo.cs
+++ b/PokemonBattleEngineClient/Models/TeamInfo.cs
@@ -1,5 +1,4 @@
 ﻿using Kermalis.PokemonBattleEngine.Data;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 
 namespace Kermalis.PokemonBattleEngineClient.Models
@@ -22,14 +21,14 @@ namespace Kermalis.PokemonBattleEngineClient.Models
                 OnPropertyChanged(nameof(Name));
             }
         }
-        private ObservableCollection<PBEPokemonShell> party;
-        public ObservableCollection<PBEPokemonShell> Party
+        private PBETeamShell shell;
+        public PBETeamShell Shell
         {
-            get => party;
+            get => shell;
             set
             {
-                party = value;
-                OnPropertyChanged(nameof(Party));
+                shell = value;
+                OnPropertyChanged(nameof(Shell));
             }
         }
     }

--- a/PokemonBattleEngineClient/Views/TeamBuilderView.xaml
+++ b/PokemonBattleEngineClient/Views/TeamBuilderView.xaml
@@ -62,7 +62,7 @@
           <Image Grid.Row="2" Grid.Column="0" Stretch="None" HorizontalAlignment="Left" Source="{Binding Source='Nickname:', Converter={x:Static infrastructure:ObjectToTextBitmapConverter.Instance}, ConverterParameter=MenuWhite, Mode=OneWay}"/>
           <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Shell.Nickname}"/>
           <Image Grid.Row="3" Grid.Column="0" Stretch="None" HorizontalAlignment="Left" Source="{Binding Source='Level:', Converter={x:Static infrastructure:ObjectToTextBitmapConverter.Instance}, ConverterParameter=MenuWhite, Mode=OneWay}"/>
-          <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="{Binding Settings.MinLevel, Mode=OneWay}" Maximum="{Binding Settings.MaxLevel, Mode=OneWay}" ClipValueToMinMax="true" Value="{Binding Shell.Level}"/>
+          <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="{Binding Team.Shell.Settings.MinLevel, Mode=OneWay}" Maximum="{Binding Team.Shell.Settings.MaxLevel, Mode=OneWay}" ClipValueToMinMax="true" Value="{Binding Shell.Level}"/>
           <Image Grid.Row="4" Grid.Column="0" Stretch="None" HorizontalAlignment="Left" Source="{Binding Source='Friendship:', Converter={x:Static infrastructure:ObjectToTextBitmapConverter.Instance}, ConverterParameter=MenuWhite, Mode=OneWay}"/>
           <NumericUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="255" ClipValueToMinMax="true" Value="{Binding Shell.Friendship}"/>
           <Image Grid.Row="5" Grid.Column="0" Stretch="None" HorizontalAlignment="Left" Source="{Binding Source='Ability:', Converter={x:Static infrastructure:ObjectToTextBitmapConverter.Instance}, ConverterParameter=MenuWhite, Mode=OneWay}"/>
@@ -119,7 +119,7 @@
           </ItemsControl.ItemsPanel>
           <ItemsControl.ItemTemplate>
             <DataTemplate>
-              <NumericUpDown Width="60" Minimum="0" Maximum="{Binding RelativeSource={RelativeSource AncestorType=views:TeamBuilderView}, Path=Settings.MaxIVs, Mode=OneWay}" ClipValueToMinMax="True" Value="{Binding Value}"/>
+              <NumericUpDown Width="60" Minimum="0" Maximum="{Binding RelativeSource={RelativeSource AncestorType=views:TeamBuilderView}, Path=Team.Shell.Settings.MaxIVs, Mode=OneWay}" ClipValueToMinMax="True" Value="{Binding Value}"/>
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>
@@ -139,7 +139,7 @@
             <DataTemplate>
               <StackPanel Orientation="Vertical">
                 <ComboBox Width="100" Items="{Binding Allowed, Mode=OneWay}" ItemTemplate="{StaticResource MenuBlack}" SelectedItem="{Binding Move}" IsEnabled="{Binding IsMoveEditable, Mode=OneWay}"/>
-                <NumericUpDown Width="60" Minimum="0" Maximum="{Binding RelativeSource={RelativeSource AncestorType=views:TeamBuilderView}, Path=Settings.MaxPPUps, Mode=OneWay}" ClipValueToMinMax="True" IsEnabled="{Binding IsPPUpsEditable, Mode=OneWay}" Value="{Binding PPUps}"/>
+                <NumericUpDown Width="60" Minimum="0" Maximum="{Binding RelativeSource={RelativeSource AncestorType=views:TeamBuilderView}, Path=Team.Shell.Settings.MaxPPUps, Mode=OneWay}" ClipValueToMinMax="True" IsEnabled="{Binding IsPPUpsEditable, Mode=OneWay}" Value="{Binding PPUps}"/>
               </StackPanel>
             </DataTemplate>
           </ItemsControl.ItemTemplate>
@@ -159,7 +159,7 @@
           </StackPanel>
         </Button>
       </StackPanel>
-      <ListBox Name="Party" Items="{Binding Team.Party, Mode=OneWay}" SelectedItem="{Binding Shell}" SelectionMode="AlwaysSelected">
+      <ListBox Name="Party" Items="{Binding Team.Shell, Mode=OneWay}" SelectedItem="{Binding Shell}" SelectionMode="AlwaysSelected">
         <ListBox.ItemTemplate>
           <DataTemplate>
             <StackPanel Spacing="4" Orientation="Horizontal">

--- a/PokemonBattleEngineClient/Views/TeamBuilderView.xaml.cs
+++ b/PokemonBattleEngineClient/Views/TeamBuilderView.xaml.cs
@@ -104,7 +104,7 @@ namespace Kermalis.PokemonBattleEngineClient.Views
             var t = new TeamInfo
             {
                 Name = $"Team {DateTime.Now.Ticks}",
-                Shell = new PBETeamShell(PBESettings.DefaultSettings, 1, true)
+                Shell = new PBETeamShell(new PBESettings(PBESettings.DefaultSettings), 1, true)
             };
             Teams.Add(t);
             Team = t;

--- a/PokemonBattleEngineDiscord/BattleContext.cs
+++ b/PokemonBattleEngineDiscord/BattleContext.cs
@@ -275,8 +275,8 @@ namespace Kermalis.PokemonBattleEngineDiscord
             {
                 sb.AppendLine($"**{PBELocalizedString.GetMoveName(PBEMove.HiddenPower).English}:** {PBELocalizedString.GetTypeName(pkmn.IndividualValues.HiddenPowerType).English}/{pkmn.IndividualValues.HiddenPowerBasePower}");
             }
-            string[] moveStrs = new string[PBESettings.DefaultSettings.NumMoves];
-            for (int i = 0; i < PBESettings.DefaultSettings.NumMoves; i++)
+            string[] moveStrs = new string[PBESettings.DefaultNumMoves];
+            for (int i = 0; i < PBESettings.DefaultNumMoves; i++)
             {
                 PBEMove move = pkmn.Moves[i];
                 string str = PBELocalizedString.GetMoveName(move).English;
@@ -1271,8 +1271,8 @@ namespace Kermalis.PokemonBattleEngineDiscord
                     SocketUser user = context.battlers[Array.IndexOf(context.battle.Teams, arp.Team)];
                     var userArray = new SocketUser[] { user };
                     PBEPokemon mainPkmn = arp.Team.ActionsRequired[0];
-                    var allMessages = new List<IUserMessage>(PBESettings.DefaultSettings.MaxPartySize);
-                    var reactionsToAdd = new List<(IUserMessage Message, IEmote Reaction)>(PBESettings.DefaultSettings.MaxPartySize - 1 + PBESettings.DefaultSettings.NumMoves); // 5 switch reactions, 4 move reactions
+                    var allMessages = new List<IUserMessage>(PBESettings.DefaultMaxPartySize);
+                    var reactionsToAdd = new List<(IUserMessage Message, IEmote Reaction)>(PBESettings.DefaultMaxPartySize - 1 + PBESettings.DefaultNumMoves); // 5 switch reactions, 4 move reactions
 
                     if (mainPkmn.CanSwitchOut())
                     {

--- a/PokemonBattleEngineDiscord/BotCommands.cs
+++ b/PokemonBattleEngineDiscord/BotCommands.cs
@@ -137,7 +137,7 @@ namespace Kermalis.PokemonBattleEngineDiscord
                         .AddField("Type", mData.Type, true)
                         .AddField("Category", mData.Category, true)
                         .AddField("Priority", mData.Priority, true)
-                        .AddField("PP", Math.Max(1, mData.PPTier * PBESettings.DefaultSettings.PPMultiplier), true)
+                        .AddField("PP", Math.Max(1, mData.PPTier * PBESettings.DefaultPPMultiplier), true)
                         .AddField("Power", mData.Power == 0 ? "--" : mData.Power.ToString(), true)
                         .AddField("Accuracy", mData.Accuracy == 0 ? "--" : mData.Accuracy.ToString(), true);
                     switch (mData.Effect)

--- a/PokemonBattleEngineDiscord/BotCommands.cs
+++ b/PokemonBattleEngineDiscord/BotCommands.cs
@@ -59,12 +59,12 @@ namespace Kermalis.PokemonBattleEngineDiscord
                 else
                 {
                     PBESettings settings = PBESettings.DefaultSettings;
-                    PBEPokemonShell[] team0Party, team1Party;
+                    PBETeamShell team0Shell, team1Shell;
                     // Completely Randomized Pokémon
-                    team0Party = PBEUtils.CreateCompletelyRandomTeam(settings, true);
-                    team1Party = PBEUtils.CreateCompletelyRandomTeam(settings, true);
+                    team0Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
+                    team1Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
 
-                    var battle = new PBEBattle(PBEBattleFormat.Single, settings, team0Party, team1Party);
+                    var battle = new PBEBattle(PBEBattleFormat.Single, team0Shell, team1Shell);
                     battle.Teams[0].TrainerName = Context.User.Username;
                     battle.Teams[1].TrainerName = battler1.Username;
                     var battleContext = new BattleContext(battle, Context.User, battler1, Context.Channel);

--- a/PokemonBattleEngineDiscord/BotCommands.cs
+++ b/PokemonBattleEngineDiscord/BotCommands.cs
@@ -64,9 +64,7 @@ namespace Kermalis.PokemonBattleEngineDiscord
                     team0Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
                     team1Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
 
-                    var battle = new PBEBattle(PBEBattleFormat.Single, team0Shell, team1Shell);
-                    battle.Teams[0].TrainerName = Context.User.Username;
-                    battle.Teams[1].TrainerName = battler1.Username;
+                    var battle = new PBEBattle(PBEBattleFormat.Single, team0Shell, Context.User.Username, team1Shell, battler1.Username);
                     var battleContext = new BattleContext(battle, Context.User, battler1, Context.Channel);
                 }
             }

--- a/PokemonBattleEngineExtras/AIBattleTest.cs
+++ b/PokemonBattleEngineExtras/AIBattleTest.cs
@@ -46,9 +46,7 @@ namespace Kermalis.PokemonBattleEngineExtras
                 PBECompetitivePokemonShells.Victini_Uber
             };*/
 
-            var battle = new PBEBattle(PBEBattleFormat.Double, team0Shell, team1Shell);
-            battle.Teams[0].TrainerName = "Team 1";
-            battle.Teams[1].TrainerName = "Team 2";
+            var battle = new PBEBattle(PBEBattleFormat.Double, team0Shell, "Team 1", team1Shell, "Team 2");
             battle.OnNewEvent += PBEBattle.ConsoleBattleEventHandler;
             battle.OnStateChanged += Battle_OnStateChanged;
             try

--- a/PokemonBattleEngineExtras/AIBattleTest.cs
+++ b/PokemonBattleEngineExtras/AIBattleTest.cs
@@ -1,5 +1,4 @@
-﻿using Kermalis.PokemonBattleEngine;
-using Kermalis.PokemonBattleEngine.AI;
+﻿using Kermalis.PokemonBattleEngine.AI;
 using Kermalis.PokemonBattleEngine.Battle;
 using Kermalis.PokemonBattleEngine.Data;
 using System;
@@ -21,14 +20,14 @@ namespace Kermalis.PokemonBattleEngineExtras
             Console.WriteLine("----- Pokémon Battle Engine Test -----");
 
             var settings = new PBESettings { NumMoves = 12 };
-            PBEPokemonShell[] team0Party, team1Party;
+            PBETeamShell team0Shell, team1Shell;
 
             // Completely Randomized Pokémon
-            team0Party = PBEUtils.CreateCompletelyRandomTeam(settings, true);
-            team1Party = PBEUtils.CreateCompletelyRandomTeam(settings, true);
+            team0Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
+            team1Shell = new PBETeamShell(settings, settings.MaxPartySize, true);
 
             // Predefined Pokémon
-            /*team0Party = new PBEPokemonShell[]
+            /*team0Shell = new PBEPokemonShell[]
             {
                 PBECompetitivePokemonShells.Zoroark_VGC,
                 PBECompetitivePokemonShells.Volcarona_VGC,
@@ -37,7 +36,7 @@ namespace Kermalis.PokemonBattleEngineExtras
                 PBECompetitivePokemonShells.Vanilluxe_VGC,
                 PBECompetitivePokemonShells.Chandelure_VGC
             };
-            team1Party = new PBEPokemonShell[]
+            team1Shell = new PBEPokemonShell[]
             {
                 PBECompetitivePokemonShells.Arceus_Uber,
                 PBECompetitivePokemonShells.Darkrai_Uber,
@@ -47,7 +46,7 @@ namespace Kermalis.PokemonBattleEngineExtras
                 PBECompetitivePokemonShells.Victini_Uber
             };*/
 
-            var battle = new PBEBattle(PBEBattleFormat.Double, settings, team0Party, team1Party);
+            var battle = new PBEBattle(PBEBattleFormat.Double, team0Shell, team1Shell);
             battle.Teams[0].TrainerName = "Team 1";
             battle.Teams[1].TrainerName = "Team 2";
             battle.OnNewEvent += PBEBattle.ConsoleBattleEventHandler;

--- a/PokemonBattleEngineServer/BattleServer.cs
+++ b/PokemonBattleEngineServer/BattleServer.cs
@@ -73,16 +73,16 @@ namespace Kermalis.PokemonBattleEngineServer
                             break;
                         }
                     }
-                    client.PlayerName = Utils.RandomElement(new string[] { "Sasha", "Nikki", "Lara", "Violet", "Naomi", "Rose", "Sabrina", "Nicole" });
+                    client.TrainerName = Utils.RandomElement(new string[] { "Sasha", "Nikki", "Lara", "Violet", "Naomi", "Rose", "Sabrina", "Nicole" });
                     readyPlayers.Add(client);
-                    Console.WriteLine($"Client connected ({client.BattleId} {client.PlayerName})");
+                    Console.WriteLine($"Client connected ({client.BattleId} {client.TrainerName})");
 
                     foreach (Player player in readyPlayers.ToArray()) // Copy so a disconnect doesn't cause an exception
                     {
                         // Alert new player of all other players that have already joined
                         if (player != client)
                         {
-                            client.Send(new PBEPlayerJoinedPacket(false, player.BattleId, player.PlayerName));
+                            client.Send(new PBEPlayerJoinedPacket(false, player.BattleId, player.TrainerName));
                             if (!client.WaitForResponse())
                             {
                                 return;
@@ -91,7 +91,7 @@ namespace Kermalis.PokemonBattleEngineServer
                         // Alert all players that this new player joined (including him/herself)
                         if (player.Socket != null)
                         {
-                            player.Send(new PBEPlayerJoinedPacket(player == client, client.BattleId, client.PlayerName));
+                            player.Send(new PBEPlayerJoinedPacket(player == client, client.BattleId, client.TrainerName));
                             if (!player.WaitForResponse() && player.BattleId < 2)
                             {
                                 return;
@@ -115,8 +115,6 @@ namespace Kermalis.PokemonBattleEngineServer
                         state = ServerState.WaitingForParties;
                         Console.WriteLine("Two players connected! Waiting for parties...");
                         battlers = readyPlayers.ToArray();
-                        battle.Teams[0].TrainerName = battlers[0].PlayerName;
-                        battle.Teams[1].TrainerName = battlers[1].PlayerName;
                         SendTo(battlers, new PBEPartyRequestPacket());
                     }
                 }
@@ -136,7 +134,7 @@ namespace Kermalis.PokemonBattleEngineServer
                     resetEvent.WaitOne();
                     readyPlayers.Remove(client);
 
-                    Console.WriteLine($"Client disconnected ({client.BattleId} {client.PlayerName})");
+                    Console.WriteLine($"Client disconnected ({client.BattleId} {client.TrainerName})");
                     if (client.BattleId < 2)
                     {
                         if (state != ServerState.WaitingForPlayers)
@@ -208,7 +206,7 @@ namespace Kermalis.PokemonBattleEngineServer
                 {
                     return;
                 }
-                PBEBattle.CreateTeamParty(battle.Teams[player.BattleId], player.TeamShell);
+                PBEBattle.CreateTeamParty(battle.Teams[player.BattleId], player.TeamShell, player.TrainerName);
             }
         }
         public void ActionsSubmitted(Player player, IEnumerable<PBEAction> actions)
@@ -224,7 +222,7 @@ namespace Kermalis.PokemonBattleEngineServer
                     return;
                 }
                 PBETeam team = battle.Teams[player.BattleId];
-                Console.WriteLine($"Received actions from {player.PlayerName}!");
+                Console.WriteLine($"Received actions from {player.TrainerName}!");
                 if (!PBEBattle.SelectActionsIfValid(team, actions))
                 {
                     Console.WriteLine("Actions are invalid!");
@@ -245,7 +243,7 @@ namespace Kermalis.PokemonBattleEngineServer
                     return;
                 }
                 PBETeam team = battle.Teams[player.BattleId];
-                Console.WriteLine($"Received switches from {player.PlayerName}!");
+                Console.WriteLine($"Received switches from {player.TrainerName}!");
                 if (!PBEBattle.SelectSwitchesIfValid(team, switches))
                 {
                     Console.WriteLine("Switches are invalid!");
@@ -274,7 +272,7 @@ namespace Kermalis.PokemonBattleEngineServer
                             }
                             catch (Exception e)
                             {
-                                Console.WriteLine($"Illegal moveset received from {player.PlayerName}");
+                                Console.WriteLine($"Illegal moveset received from {player.TrainerName}");
                                 Console.WriteLine(e.Message);
                                 CancelMatch();
                                 return;

--- a/PokemonBattleEngineServer/BattleServer.cs
+++ b/PokemonBattleEngineServer/BattleServer.cs
@@ -208,7 +208,7 @@ namespace Kermalis.PokemonBattleEngineServer
                 {
                     return;
                 }
-                PBEBattle.CreateTeamParty(battle.Teams[player.BattleId], player.Party);
+                PBEBattle.CreateTeamParty(battle.Teams[player.BattleId], player.TeamShell);
             }
         }
         public void ActionsSubmitted(Player player, IEnumerable<PBEAction> actions)
@@ -224,7 +224,7 @@ namespace Kermalis.PokemonBattleEngineServer
                     return;
                 }
                 PBETeam team = battle.Teams[player.BattleId];
-                Console.WriteLine($"Received actions from {team.TrainerName}!");
+                Console.WriteLine($"Received actions from {player.PlayerName}!");
                 if (!PBEBattle.SelectActionsIfValid(team, actions))
                 {
                     Console.WriteLine("Actions are invalid!");
@@ -245,7 +245,7 @@ namespace Kermalis.PokemonBattleEngineServer
                     return;
                 }
                 PBETeam team = battle.Teams[player.BattleId];
-                Console.WriteLine($"Received switches from {team.TrainerName}!");
+                Console.WriteLine($"Received switches from {player.PlayerName}!");
                 if (!PBEBattle.SelectSwitchesIfValid(team, switches))
                 {
                     Console.WriteLine("Switches are invalid!");
@@ -264,7 +264,7 @@ namespace Kermalis.PokemonBattleEngineServer
                     resetEvent.Reset();
                     foreach (Player player in battlers)
                     {
-                        foreach (PBEPokemonShell shell in player.Party)
+                        foreach (PBEPokemonShell shell in player.TeamShell)
                         {
                             try
                             {

--- a/PokemonBattleEngineServer/Player.cs
+++ b/PokemonBattleEngineServer/Player.cs
@@ -3,7 +3,6 @@ using Ether.Network.Packets;
 using Kermalis.PokemonBattleEngine.Data;
 using Kermalis.PokemonBattleEngine.Packets;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
@@ -14,7 +13,7 @@ namespace Kermalis.PokemonBattleEngineServer
         public ManualResetEvent ResetEvent { get; } = new ManualResetEvent(true);
         public string PlayerName { get; set; }
         public int BattleId { get; set; } = int.MaxValue;
-        public IEnumerable<PBEPokemonShell> Party { get; private set; }
+        public PBETeamShell TeamShell { get; private set; }
 
         public bool WaitForResponse()
         {
@@ -53,8 +52,16 @@ namespace Kermalis.PokemonBattleEngineServer
                     }
                     case PBEPartyResponsePacket prp:
                     {
-                        Party = prp.Party;
-                        ser.PartySubmitted(this);
+                        Console.WriteLine($"Received team from {PlayerName}!");
+                        if (TeamShell == null)
+                        {
+                            TeamShell = prp.TeamShell;
+                            ser.PartySubmitted(this);
+                        }
+                        else
+                        {
+                            Console.WriteLine("Team submitted multiple times!");
+                        }
                         break;
                     }
                     case PBESwitchInResponsePacket sirp:

--- a/PokemonBattleEngineServer/Player.cs
+++ b/PokemonBattleEngineServer/Player.cs
@@ -11,7 +11,7 @@ namespace Kermalis.PokemonBattleEngineServer
     internal class Player : NetUser
     {
         public ManualResetEvent ResetEvent { get; } = new ManualResetEvent(true);
-        public string PlayerName { get; set; }
+        public string TrainerName { get; set; }
         public int BattleId { get; set; } = int.MaxValue;
         public PBETeamShell TeamShell { get; private set; }
 
@@ -20,7 +20,7 @@ namespace Kermalis.PokemonBattleEngineServer
             bool receivedResponseInTime = ResetEvent.WaitOne(1000 * 5);
             if (!receivedResponseInTime)
             {
-                Console.WriteLine($"Kicking client ({BattleId} {PlayerName})");
+                Console.WriteLine($"Kicking client ({BattleId} {TrainerName})");
                 Server.DisconnectClient(Id);
             }
             return receivedResponseInTime;
@@ -52,7 +52,7 @@ namespace Kermalis.PokemonBattleEngineServer
                     }
                     case PBEPartyResponsePacket prp:
                     {
-                        Console.WriteLine($"Received team from {PlayerName}!");
+                        Console.WriteLine($"Received team from {TrainerName}!");
                         if (TeamShell == null)
                         {
                             TeamShell = prp.TeamShell;


### PR DESCRIPTION
Closes #176 

Done:
* Ability to convert PBESettings to and from bytes and strings
* PBESettings.Equals() and PBESettings.IsReadOnly
* Store PBESettings in replays and team json files
* PBETeamShell (Also uses a single PBESettings object for the entire team)
* Do not use PBESettings.MaxLevel for stat/damage calculation
* Listen for PBESettings changes in TeamBuilderView, PBEMovesetBuilder, PBEIndividualValueCollection, PBEEffortValueCollection, PBEPokemonShell, and PBETeamShell

TODO:
* PBEPokemonShell should be able to function without a PBETeamShell and should still work after being removed from one
* Add public setters for PBESettings in PBEMovesetBuilder, PBEEffortValueCollection, PBEIndividualValueCollection, PBETeamShell, and PBEPokemonShell
* Settings editor in client
* #200 